### PR TITLE
Update value default `override` `true` to `false` in `HasLinkItemActiveClass`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Bug #9: Update phpdoc `CSS` class assignments (@terabytesoftw)
 - Bug #10: Better naming `HasLinkActiveClass` and `HasLinkDisableClass` (@terabytesoftw)
 - Enh #11: Add trait `HasLinkItemActiveClass` class (@terabytesoftw)
+- Bug #12: Update value default `override` `true` to `false` in `HasLinkItemActiveClass` (@terabytesoftw)
 
 ## 0.1.0 March 5, 2024
 

--- a/src/Component/HasListItemActiveClass.php
+++ b/src/Component/HasListItemActiveClass.php
@@ -13,7 +13,7 @@ trait HasListItemActiveClass
      * @psalm-var string|string[]
      */
     protected array|string $listItemActiveClass = '';
-    protected bool $overrideListItemActiveClass = true;
+    protected bool $overrideListItemActiveClass = false;
 
     /**
      * Set the `CSS` class to be appended to the list item active class.
@@ -25,7 +25,7 @@ trait HasListItemActiveClass
      *
      * @psalm-param string|string[] $value
      */
-    public function listItemActiveClass(array|string $value, bool $override = true): static
+    public function listItemActiveClass(array|string $value, bool $override = false): static
     {
         $new = clone $this;
         $new->listItemActiveClass = $value;

--- a/tests/Component/HasListItemActiveClassTest.php
+++ b/tests/Component/HasListItemActiveClassTest.php
@@ -17,7 +17,7 @@ final class HasListItemActiveClassTest extends \PHPUnit\Framework\TestCase
         };
 
         $this->assertNotSame($instance, $instance->listItemActiveClass($instance->listItemAttributes));
-        $this->assertNotSame($instance, $instance->listItemActiveClass($instance->listItemAttributes, false));
+        $this->assertNotSame($instance, $instance->listItemActiveClass($instance->listItemAttributes, true));
     }
 
     public function testOverrideActiveClass(): void
@@ -33,13 +33,13 @@ final class HasListItemActiveClassTest extends \PHPUnit\Framework\TestCase
             }
         };
 
+        $this->assertFalse($instance->getOverrideListItemActiveClass());
+
+        $instance = $instance->listItemActiveClass($instance->listItemAttributes, true);
+
         $this->assertTrue($instance->getOverrideListItemActiveClass());
 
         $instance = $instance->listItemActiveClass($instance->listItemAttributes);
-
-        $this->assertTrue($instance->getOverrideListItemActiveClass());
-
-        $instance = $instance->listItemActiveClass($instance->listItemAttributes, false);
 
         $this->assertFalse($instance->getOverrideListItemActiveClass());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
