### PR TITLE
Fix `linkAriaCurrent()` and `listItemAriaCurrent()` methods to accept a boolean value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Enh #21: Add trait `HasTag` class (@terabytesoftw)
 - Enh #22: Add trait `HasLinkAreaCurrent` class (@terabytesoftw)
 - Enh #23: Add trait `HasListItemAreaCurrent` class (@terabytesoftw)
+- Bug #24: Fix `linkAriaCurrent()` and `listItemAriaCurrent()` methods to accept a boolean value. (@terabytesoftw)
 
 ## 0.1.0 March 5, 2024
 

--- a/src/Component/HasLinkAreaCurrent.php
+++ b/src/Component/HasLinkAreaCurrent.php
@@ -13,11 +13,16 @@ trait HasLinkAreaCurrent
 
     /**
      * Set the link aria current attribute.
+     *
+     * @param bool $value Whether the link aria current attribute is `true` or `false`.
+     * If `true` the add aria-current attribute to the link.
+     *
+     * @return static A new instance of the current class with the specified link aria current attribute.
      */
-    public function linkAriaCurrent(): static
+    public function linkAriaCurrent(bool $value): static
     {
         $new = clone $this;
-        $new->linkAriaCurrent = true;
+        $new->linkAriaCurrent = $value;
 
         return $new;
     }

--- a/src/Component/HasListItemAreaCurrent.php
+++ b/src/Component/HasListItemAreaCurrent.php
@@ -13,8 +13,13 @@ trait HasListItemAreaCurrent
 
     /**
      * Set the list item aria current attribute.
+     *
+     * @param bool $value Whether the list item aria current attribute is `true` or `false`.
+     * If `true` the add aria-current attribute to the list item <li> element.
+     *
+     * @return static A new instance of the current class with the specified list item aria current attribute.
      */
-    public function listItemAriaCurrent(): static
+    public function listItemAriaCurrent(bool $value): static
     {
         $new = clone $this;
         $new->listItemAriaCurrent = true;

--- a/tests/Component/HasLinkAreaCurrentTest.php
+++ b/tests/Component/HasLinkAreaCurrentTest.php
@@ -14,7 +14,7 @@ final class HasLinkAreaCurrentTest extends \PHPUnit\Framework\TestCase
             use HasLinkAreaCurrent;
         };
 
-        $this->assertNotSame($instance, $instance->linkAriaCurrent());
+        $this->assertNotSame($instance, $instance->linkAriaCurrent(false));
     }
 
     public function testIsLinkAriaCurrent(): void
@@ -24,6 +24,6 @@ final class HasLinkAreaCurrentTest extends \PHPUnit\Framework\TestCase
         };
 
         $this->assertFalse($instance->isLinkAriaCurrent());
-        $this->assertTrue($instance->linkAriaCurrent()->isLinkAriaCurrent());
+        $this->assertTrue($instance->linkAriaCurrent(true)->isLinkAriaCurrent());
     }
 }

--- a/tests/Component/HasListItemAreaCurrentTest.php
+++ b/tests/Component/HasListItemAreaCurrentTest.php
@@ -14,7 +14,7 @@ final class HasListItemAreaCurrentTest extends \PHPUnit\Framework\TestCase
             use HasListItemAreaCurrent;
         };
 
-        $this->assertNotSame($instance, $instance->listItemAriaCurrent());
+        $this->assertNotSame($instance, $instance->listItemAriaCurrent(false));
     }
 
     public function testIsLinkAriaCurrent(): void
@@ -24,6 +24,6 @@ final class HasListItemAreaCurrentTest extends \PHPUnit\Framework\TestCase
         };
 
         $this->assertFalse($instance->isListItemAriaCurrent());
-        $this->assertTrue($instance->listItemAriaCurrent()->isListItemAriaCurrent());
+        $this->assertTrue($instance->listItemAriaCurrent(true)->isListItemAriaCurrent());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
