### PR TITLE
feat(mixin): Add `getAttribute()` method to `HasAttributes` mixin for retrieving attribute values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Bug #30: Update `.editorconfig` and `phpunit.xml.dist` for consistency and clarity (@terabytesoftw)
 - Bug #31: Update import paths and fix namespace declarations in configuration files (@terabytesoftw)
 - Bug #32: Add `NullableTypeDeclarationFixer` to the configuration and update skip rules in `ECS` configuration (@terabytesoftw)
+- Enh #33: Add `getAttribute()` method to `HasAttributes` mixin for retrieving attribute values (@terabytesoftw)
 
 ## 0.2.0 March 30, 2024
 

--- a/src/HasAttributes.php
+++ b/src/HasAttributes.php
@@ -121,6 +121,29 @@ trait HasAttributes
     }
 
     /**
+     * Returns the value of a single HTML attribute.
+     *
+     * If the attribute is not present, returns the provided default value.
+     *
+     * @param string|UnitEnum $key Attribute name.
+     * @param mixed $default Default value when the attribute is missing.
+     *
+     * @return mixed Attribute value or default.
+     */
+    public function getAttribute(string|UnitEnum $key, mixed $default = null): mixed
+    {
+        $normalizedKey = Enum::normalizeValue($key);
+
+        if ($normalizedKey === '' || is_string($normalizedKey) === false) {
+            throw new InvalidArgumentException(
+                Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage($normalizedKey),
+            );
+        }
+
+        return $this->attributes[$normalizedKey] ?? $default;
+    }
+
+    /**
      * Returns the array of HTML attributes for the element.
      *
      * @return array Attributes array assigned to the element.

--- a/tests/HasAttributesTest.php
+++ b/tests/HasAttributesTest.php
@@ -12,7 +12,7 @@ use Stringable;
 use UIAwesome\Html\Mixin\Exception\Message;
 use UIAwesome\Html\Mixin\HasAttributes;
 use UIAwesome\Html\Mixin\Tests\Support\Provider\AttributeProvider;
-use UIAwesome\Html\Mixin\Tests\Support\Stub\Enum\Priority;
+use UIAwesome\Html\Mixin\Tests\Support\Stub\Enum\{Priority, Status};
 use UnitEnum;
 
 /**
@@ -29,6 +29,7 @@ use UnitEnum;
  * - Correct assignment and retrieval of attribute value.
  * - Immutability of the mixin when setting attributes.
  * - Removal of specific attributes from the attribute set.
+ * - Retrieving individual attribute values by key.
  * - Setting and retrieving single attribute values.
  *
  * @copyright Copyright (C) 2025 Terabytesoftw.
@@ -37,6 +38,90 @@ use UnitEnum;
 #[Group('mixin')]
 final class HasAttributesTest extends TestCase
 {
+    public function testGetAttributeDoesNotMutateInstance(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+        };
+
+        $instance = $instance->attributes(['id' => 'my-id']);
+        $originalAttributes = $instance->getAttributes();
+
+        $instance->getAttribute('id');
+        $instance->getAttribute('nonexistent', 'default');
+
+        self::assertSame(
+            $originalAttributes,
+            $instance->getAttributes(),
+            'Should return the original attributes array when calling get attribute, ensuring immutability.',
+        );
+    }
+
+    public function testGetAttributeReturnsDefaultWhenAttributeDoesNotExist(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+        };
+
+        self::assertSame(
+            'default-value',
+            $instance->getAttribute('nonexistent', 'default-value'),
+            'Should return the default value when the attribute does not exist.',
+        );
+        self::assertSame(
+            42,
+            $instance->getAttribute('missing', 42),
+            'Should return the default value when the attribute does not exist.',
+        );
+    }
+
+    public function testGetAttributeReturnsNullWhenAttributeDoesNotExist(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+        };
+
+        self::assertNull(
+            $instance->getAttribute('nonexistent'),
+            "Should return 'null' when the attribute does not exist and no default is provided.",
+        );
+    }
+
+    public function testGetAttributeReturnsValueWhenAttributeExists(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+        };
+
+        $instance = $instance->attributes(['id' => 'my-id', 'class' => 'my-class']);
+
+        self::assertSame(
+            'my-id',
+            $instance->getAttribute('id'),
+            'Should return the value of the attribute when it exists.',
+        );
+        self::assertSame(
+            'my-class',
+            $instance->getAttribute('class'),
+            'Should return the value of the attribute when it exists.',
+        );
+    }
+
+    public function testGetAttributeWithEnumKey(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+        };
+
+        $instance = $instance->addAttribute(Status::ACTIVE, 'active-status');
+
+        self::assertSame(
+            'active-status',
+            $instance->getAttribute(Status::ACTIVE),
+            'Should return the value when using an enum key.',
+        );
+    }
+
     public function testRemoveAttributeValue(): void
     {
         $instance = new class {
@@ -222,6 +307,34 @@ final class HasAttributesTest extends TestCase
             $instance->getAttributes(),
             $message,
         );
+    }
+
+    public function testThrowInvalidArgumentExceptionForGetAttributeEmptyKey(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(''),
+        );
+
+        $instance->getAttribute('');
+    }
+
+    public function testThrowInvalidArgumentExceptionForGetAttributeInvalidKey(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage(2),
+        );
+
+        $instance->getAttribute(Priority::HIGH);
     }
 
     public function testThrowInvalidArgumentExceptionForSetSingleAttributeWithEmptyKey(): void


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new method to retrieve individual attribute values with an optional default fallback value. Supports using enum types as attribute identifiers.

* **Tests**
  * Added comprehensive test coverage including validation, immutability checks, and support for enum keys.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->