### PR TITLE
fix(docs): Remove redundant usage examples from `HasAttributes`, `HasPrefixCollection`, and `HasSuffixCollection` traits for clarity.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.3.1 Under development
 
+- Bug #38: Remove redundant usage examples from `HasAttributes`, `HasPrefixCollection`, and `HasSuffixCollection` traits for clarity (@terabytesoftw)
+
 ## 0.3.0 January 18, 2026
 
 - Enh #27: Refactor codebase to improve performance (@terabytesoftw)

--- a/src/HasAttributes.php
+++ b/src/HasAttributes.php
@@ -56,16 +56,9 @@ trait HasAttributes
      *
      * Usage example:
      * ```php
-     * // sets a single attribute
      * $element->addAttribute('id', 'my-id');
-     *
-     * // sets single attribute with an enum key
      * $element->addAttribute(DataProperty::ID, 'my-id');
-     *
-     * // sets single attribute with an enum value
      * $element->addAttribute('size', ButtonSize::SMALL);
-     *
-     * // removes attribute
      * $element->addAttribute('id', null);
      * ```
      */
@@ -102,10 +95,7 @@ trait HasAttributes
      *
      * Usage example:
      * ```php
-     * // sets multiple attributes
      * $element->attributes(['id' => 'my-id', 'data-role' => 'button']);
-     *
-     * // sets multiple attributes with an enum value
      * $element->attributes(['size' => ButtonSize::LARGE, 'disabled' => true]);
      * ```
      */
@@ -127,6 +117,12 @@ trait HasAttributes
      * @param mixed $default Default value when the attribute is missing.
      *
      * @return mixed Attribute value or default.
+     *
+     * Usage example:
+     * ```php
+     * $id = $element->getAttribute('id', 'default-id');
+     * $id = $element->getAttribute(DataProperty::ID, 'default-id');
+     * ```
      */
     public function getAttribute(string|UnitEnum $key, mixed $default = null): mixed
     {
@@ -169,10 +165,7 @@ trait HasAttributes
      *
      * Usage example:
      * ```php
-     * // removes attribute
      * $element->removeAttribute('id');
-     *
-     * // removes attribute with an enum key
      * $element->removeAttribute(DataProperty::ID);
      * ```
      */

--- a/src/HasPrefixCollection.php
+++ b/src/HasPrefixCollection.php
@@ -127,10 +127,7 @@ trait HasPrefixCollection
      *
      * Usage example:
      * ```php
-     * // default
      * $element->prefixTag(\UIAwesome\Html\Interop\Inline::SPAN);
-     *
-     * // no rendering of prefix tag
      * $element->prefixTag(false);
      * ```
      */

--- a/src/HasSuffixCollection.php
+++ b/src/HasSuffixCollection.php
@@ -127,10 +127,7 @@ trait HasSuffixCollection
      *
      * Usage example:
      * ```php
-     * // default
      * $element->suffixTag(\UIAwesome\Html\Interop\Inline::SPAN);
-     *
-     * // no rendering of suffix tag
      * $element->suffixTag(false);
      * ```
      */


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed redundant usage examples and simplified documentation formatting across multiple modules for improved clarity and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->