### PR TITLE
fix(docs): Remove references to `ecs.php` and `rector.php` from development documentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Enh #40: Add `php-forge/coding-standard` to development dependencies for code quality checks (@terabytesoftw)
 - Bug #41: Remove redundant cURL commands for `ecs.php` and `rector.php` in scripts section of `composer.json` (@terabytesoftw)
+- Bug #42: Remove references to `ecs.php` and `rector.php` from development documentation (@terabytesoftw)
 
 ## 0.3.1 January 20, 2026
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -20,11 +20,9 @@ This command updates the following configuration files:
 | `.editorconfig`    | Editor settings and code style configuration |
 | `.gitattributes`   | Git attributes and file handling rules       |
 | `.gitignore`       | Git ignore patterns and exclusions           |
-| `ecs.php`          | Easy Coding Standard configuration           |
 | `infection.json5`  | Infection mutation testing configuration     |
 | `phpstan.neon`     | PHPStan static analysis configuration        |
 | `phpunit.xml.dist` | PHPUnit test configuration                   |
-| `rector.php`       | Rector refactoring configuration             |
 
 ### When to Run
 


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development documentation by removing references to ecs.php and rector.php.
  * Updated changelog entry for version 0.3.2 to document these documentation changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->