### PR TITLE
fix(docs): Remove redundant ignore rule in `actionlint.yml` configuration and update Rector command in `composer.json` to remove unnecessary 'src' argument.

### DIFF
--- a/.github/linters/actionlint.yml
+++ b/.github/linters/actionlint.yml
@@ -4,4 +4,3 @@ paths:
     ignore:
       - '"pull_request" section is alias node but mapping node is expected'
       - '"push" section is alias node but mapping node is expected'
-      - "section is alias node but mapping node is expected"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bug #43: Add section for automated refactoring using `Rector` in testing documentation (@terabytesoftw)
 - Bug #44: Update examples in `testing.md` for running Composer script with arguments (@terabytesoftw)
 - Bug #45: Update command syntax in `development.md` and `testing.md` for clarity and consistency (@terabytesoftw)
+- Bug #46: Remove redundant ignore rule in `actionlint.yml` configuration and update Rector command in `composer.json` to remove unnecessary 'src' argument (@terabytesoftw)
 
 ## 0.3.2 January 24, 2026
 
@@ -30,7 +31,6 @@
 - Bug #35: Improve `testing.md` for clarity and consistency in Composer script usage (@terabytesoftw)
 - Bug #36: Update documentation for various traits and enums to enhance clarity and consistency (@terabytesoftw)
 - Bug #37: Update documentation for test classes to enhance clarity and consistency (@terabytesoftw)
-
 - Enh #26: Update `ui-awesome/html-helper` to `0.2` and move `Components` to `ui-awesome/html-core-component` (@terabytesoftw)
 
 ## 0.1.2 March 14, 2024
@@ -65,4 +65,4 @@
 
 ## 0.1.0 March 5, 2024
 
-- Initial release
+- Enh #1: Initial commit (@terabytesoftw)

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "ecs": "./vendor/bin/ecs --fix",
         "mutation": "./vendor/bin/infection --threads=4 --ignore-msi-with-no-mutations --min-msi=100 --min-covered-msi=100",
         "mutation-static": "./vendor/bin/infection --threads=4 --ignore-msi-with-no-mutations --min-msi=100 --min-covered-msi=100 --static-analysis-tool=phpstan --static-analysis-tool-options='--memory-limit=-1'",
-        "rector": "./vendor/bin/rector process src",
+        "rector": "./vendor/bin/rector process",
         "static": "./vendor/bin/phpstan --memory-limit=-1",
         "sync-metadata": [
             "curl -fsSL -o .editorconfig https://raw.githubusercontent.com/yii2-extensions/template/main/.editorconfig",

--- a/tests/Support/Provider/AttributeProvider.php
+++ b/tests/Support/Provider/AttributeProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Mixin\Tests\Support\Provider;
 
+use Closure;
 use UIAwesome\Html\Mixin\Values\AttributeProperty;
 use UnitEnum;
 
@@ -28,7 +29,7 @@ final class AttributeProvider
      *
      * @return array Test data for single attribute scenarios.
      *
-     * @phpstan-return array<string, array{string|UnitEnum, scalar|\Closure(): mixed|null, mixed[], string}>
+     * @phpstan-return array<string, array{string|UnitEnum, scalar|Closure|null, mixed[], string}>
      */
     public static function value(): array
     {

--- a/tests/Support/Provider/AttributeProvider.php
+++ b/tests/Support/Provider/AttributeProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Mixin\Tests\Support\Provider;
 
-use Closure;
 use UIAwesome\Html\Mixin\Values\AttributeProperty;
 use UnitEnum;
 
@@ -22,14 +21,14 @@ final class AttributeProvider
      * Provides test cases for single HTML attribute scenarios.
      *
      * Supplies test data for validating assignment, override, and removal of a single HTML attribute, including string
-     * keys, UnitEnum keys and values provided as scalars, \Closure, and `null`.
+     * keys, UnitEnum keys and values provided as scalars, Closure, and `null`.
      *
      * Each test case includes the attribute key, the input value, the expected attributes array, and an assertion
      * message for clear identification.
      *
      * @return array Test data for single attribute scenarios.
      *
-     * @phpstan-return array<string, array{string|UnitEnum, scalar|Closure|null, mixed[], string}>
+     * @phpstan-return array<string, array{string|UnitEnum, scalar|\Closure(): mixed|null, mixed[], string}>
      */
     public static function value(): array
     {


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of a redundant lint ignore so that one specific lint warning is no longer suppressed.

* **Chores**
  * Simplified a development tooling command to remove an unnecessary explicit argument.
  * Adjusted linting configuration to remove a redundant ignore entry.

* **Documentation**
  * Updated changelog entries and a minor test doc comment formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->