### PR TITLE
feat(tests): Add test coverage for `Closure` and `null` value resolution in `setAttribute()` method of `HasAttributes` mixin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.3.4 Under development
 
 - Dep #47: Update `ui-awesome/html-interop` requirement from `^0.2` to `^0.3` in `composer.json` (@terabytesoftw)
+- Enh #48: Add test coverage for `Closure` and `null` value resolution in `setAttribute()` method of `HasAttributes` mixin (@terabytesoftw)
 
 ## 0.3.3 January 28, 2026
 

--- a/tests/HasAttributesTest.php
+++ b/tests/HasAttributesTest.php
@@ -284,6 +284,68 @@ final class HasAttributesTest extends TestCase
         );
     }
 
+    public function testSetAttributeWithClosureValue(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+
+            /**
+             * @phpstan-param scalar|null|Closure(): mixed $value
+             */
+            public function addDataAttribute(
+                string|UnitEnum $key,
+                bool|float|int|string|Closure|Stringable|UnitEnum|null $value,
+            ): static {
+                $new = clone $this;
+
+                $new->setAttribute($key, $value, 'data-');
+
+                return $new;
+            }
+        };
+
+        $closure = static fn(): string => 'resolved-value';
+        $instance = $instance->addDataAttribute('test', $closure);
+
+        self::assertSame(
+            ['data-test' => 'resolved-value'],
+            $instance->getAttributes(),
+            'Should execute the closure and set the resolved value as the attribute value.',
+        );
+    }
+
+    public function testSetAttributeWithNullValueRemovesAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+
+            /**
+             * @phpstan-param scalar|null|Closure(): mixed $value
+             */
+            public function addAriaAttribute(
+                string|UnitEnum $key,
+                bool|float|int|string|Closure|Stringable|UnitEnum|null $value,
+            ): static {
+                $new = clone $this;
+
+                $new->setAttribute($key, $value, 'aria-', true);
+
+                return $new;
+            }
+        };
+
+        $instance = $instance
+            ->addAriaAttribute('label', 'Label')
+            ->addAriaAttribute('hidden', true)
+            ->addAriaAttribute('label', null);
+
+        self::assertSame(
+            ['aria-hidden' => 'true'],
+            $instance->getAttributes(),
+            'Should remove the attribute when null value is provided via setAttribute.',
+        );
+    }
+
     /**
      * @phpstan-param scalar|null|Closure(): mixed $value
      * @phpstan-param mixed[] $expected


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for `setAttribute()` method, including validation of Closure value execution and null value handling for attribute removal.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->