### PR TITLE
fix(mixin): Refactored attribute handling across mixins to use `AttributeBag` in `HasAttributes`, `HasContainerCollection`, `HasPrefixCollection`, and `HasSuffixCollection` for improved consistency and maintainability.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.3.6 Under development
 
 - Enh #51: Add `HasLabelCollection` mixin for managing label tag and attributes (@terabytesoftw)
+- Bug #52: Refactored attribute handling across mixins to use `AttributeBag` in `HasAttributes`, `HasContainerCollection`, `HasPrefixCollection`, and `HasSuffixCollection` for improved consistency and maintainability (@terabytesoftw)
 
 ## 0.3.5 February 9, 2026
 

--- a/src/HasAttributes.php
+++ b/src/HasAttributes.php
@@ -4,15 +4,8 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Mixin;
 
-use Closure;
-use InvalidArgumentException;
-use Stringable;
-use UIAwesome\Html\Helper\{Attributes, Enum};
-use UIAwesome\Html\Mixin\Exception\Message;
+use UIAwesome\Html\Helper\AttributeBag;
 use UnitEnum;
-
-use function is_bool;
-use function is_string;
 
 /**
  * Provides an immutable API for managing HTML attributes.
@@ -36,10 +29,10 @@ trait HasAttributes
      *
      * Usage example:
      * ```php
-     * $component = $component->addAttribute('id', 'my-id');
-     * $component = $component->addAttribute(DataProperty::ID, 'my-id');
-     * $component = $component->addAttribute('size', ButtonSize::SMALL);
-     * $component = $component->addAttribute('id', null);
+     * $component->addAttribute('id', 'my-id');
+     * $component->addAttribute(DataProperty::ID, 'my-id');
+     * $component->addAttribute('size', ButtonSize::SMALL);
+     * $component->addAttribute('id', null);
      * ```
      *
      * @param string|UnitEnum $key Attribute name.
@@ -49,20 +42,9 @@ trait HasAttributes
      */
     public function addAttribute(string|UnitEnum $key, mixed $value): static
     {
-        $normalizedKey = Enum::normalizeValue($key);
-
-        if ($normalizedKey === '' || is_string($normalizedKey) === false) {
-            throw new InvalidArgumentException(
-                Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage($normalizedKey),
-            );
-        }
-
-        if ($value === null) {
-            return $this->removeAttribute($normalizedKey);
-        }
-
         $new = clone $this;
-        $new->attributes[$normalizedKey] = $value;
+
+        AttributeBag::add($new->attributes, $key, $value);
 
         return $new;
     }
@@ -72,8 +54,8 @@ trait HasAttributes
      *
      * Usage example:
      * ```php
-     * $component = $component->attributes(['id' => 'my-id', 'data-role' => 'button']);
-     * $component = $component->attributes(['size' => ButtonSize::LARGE, 'disabled' => true]);
+     * $component->attributes(['id' => 'my-id', 'data-role' => 'button']);
+     * $component->attributes(['size' => ButtonSize::LARGE, 'disabled' => true]);
      * ```
      *
      * @param array $values Associative array of attribute keys and values.
@@ -86,7 +68,7 @@ trait HasAttributes
     {
         $new = clone $this;
 
-        $new->attributes = [...$new->attributes, ...$values];
+        AttributeBag::merge($new->attributes, $values);
 
         return $new;
     }
@@ -96,8 +78,8 @@ trait HasAttributes
      *
      * Usage example:
      * ```php
-     * $id = $component->getAttribute('id', 'default-id');
-     * $id = $component->getAttribute(DataProperty::ID, 'default-id');
+     * $component->getAttribute('id', 'default-id');
+     * $component->getAttribute(DataProperty::ID, 'default-id');
      * ```
      *
      * @param string|UnitEnum $key Attribute name.
@@ -107,15 +89,7 @@ trait HasAttributes
      */
     public function getAttribute(string|UnitEnum $key, mixed $default = null): mixed
     {
-        $normalizedKey = Enum::normalizeValue($key);
-
-        if ($normalizedKey === '' || is_string($normalizedKey) === false) {
-            throw new InvalidArgumentException(
-                Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage($normalizedKey),
-            );
-        }
-
-        return $this->attributes[$normalizedKey] ?? $default;
+        return AttributeBag::get($this->attributes, $key, $default);
     }
 
     /**
@@ -123,7 +97,7 @@ trait HasAttributes
      *
      * Usage example:
      * ```php
-     * $attributes = $component->getAttributes();
+     * $component->getAttributes();
      * ```
      *
      * @return array Attributes `array` assigned to the element.
@@ -140,8 +114,8 @@ trait HasAttributes
      *
      * Usage example:
      * ```php
-     * $component = $component->removeAttribute('id');
-     * $component = $component->removeAttribute(DataProperty::ID);
+     * $component->removeAttribute('id');
+     * $component->removeAttribute(DataProperty::ID);
      * ```
      *
      * @param string|UnitEnum $key Attribute name to remove.
@@ -150,46 +124,10 @@ trait HasAttributes
      */
     public function removeAttribute(string|UnitEnum $key): static
     {
-        $normalizedKey = Enum::normalizeValue($key);
-
         $new = clone $this;
 
-        unset($new->attributes[$normalizedKey]);
+        AttributeBag::remove($new->attributes, $key);
 
         return $new;
-    }
-
-    /**
-     * Sets a single attribute with prefix handling and value resolution.
-     *
-     * @param mixed $key Attribute key (without the prefix if a prefix is supplied).
-     * @param bool|Closure|float|int|string|Stringable|UnitEnum|null $value Attribute value, or `null` to remove the
-     * attribute.
-     * @param string $prefix Optional prefix to prepend to the key (for example, 'aria-', 'data-', 'on').
-     * @param bool $boolToString Whether to convert boolean values to `true`/`false` strings.
-     *
-     * @phpstan-param scalar|Stringable|UnitEnum|Closure(): mixed $value
-     */
-    private function setAttribute(
-        mixed $key,
-        bool|float|int|string|Closure|Stringable|UnitEnum|null $value,
-        string $prefix = '',
-        bool $boolToString = false,
-    ): void {
-        $normalizedKey = Attributes::normalizeKey($key, $prefix);
-
-        if ($value instanceof Closure) {
-            $value = $value();
-        }
-
-        if ($boolToString && is_bool($value)) {
-            $value = $value ? 'true' : 'false';
-        }
-
-        if ($value === null) {
-            unset($this->attributes[$normalizedKey]);
-        } else {
-            $this->attributes[$normalizedKey] = $value;
-        }
     }
 }

--- a/src/HasContainerCollection.php
+++ b/src/HasContainerCollection.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Mixin;
 
-use InvalidArgumentException;
 use Stringable;
-use UIAwesome\Html\Helper\{CSSClass, Enum};
+use UIAwesome\Html\Helper\{AttributeBag, CSSClass};
 use UIAwesome\Html\Interop\BlockInterface;
-use UIAwesome\Html\Mixin\Exception\Message;
 use UnitEnum;
 
 /**
@@ -41,7 +39,7 @@ trait HasContainerCollection
      *
      * Usage example:
      * ```php
-     * $component = $component->container(true);
+     * $component->container(true);
      * ```
      *
      * @param bool $value Set to `true` to render the container element, or `false` to skip rendering.
@@ -61,7 +59,7 @@ trait HasContainerCollection
      *
      * Usage example:
      * ```php
-     * $component = $component->containerAttributes(['class' => 'wrapper']);
+     * $component->containerAttributes(['class' => 'wrapper']);
      * ```
      *
      * @param array $attributes Array of attributes to apply to the container element.
@@ -73,7 +71,8 @@ trait HasContainerCollection
     public function containerAttributes(array $attributes): static
     {
         $new = clone $this;
-        $new->containerAttributes = [...$new->containerAttributes, ...$attributes];
+
+        AttributeBag::merge($new->containerAttributes, $attributes);
 
         return $new;
     }
@@ -83,8 +82,8 @@ trait HasContainerCollection
      *
      * Usage example:
      * ```php
-     * $component = $component->containerClass('new-class');
-     * $component = $component->containerClass('override-class', true);
+     * $component->containerClass('new-class');
+     * $component->containerClass('override-class', true);
      * ```
      *
      * @param string|Stringable|UnitEnum $value CSS class name to add.
@@ -95,6 +94,7 @@ trait HasContainerCollection
     public function containerClass(string|Stringable|UnitEnum $value, bool $override = false): static
     {
         $new = clone $this;
+
         CSSClass::add($new->containerAttributes, $value, $override);
 
         return $new;
@@ -105,8 +105,8 @@ trait HasContainerCollection
      *
      * Usage example:
      * ```php
-     * $component = $component->containerTag(Block::SECTION);
-     * $component = $component->containerTag(false);
+     * $component->containerTag(Block::SECTION);
+     * $component->containerTag(false);
      * ```
      *
      * @param BlockInterface|false $value Tag name for the container element, or `false` to disable.
@@ -126,7 +126,7 @@ trait HasContainerCollection
      *
      * Usage example:
      * ```php
-     * $id = $component->getContainerAttribute('id', 'default-id');
+     * $component->getContainerAttribute('id', 'default-id');
      * ```
      *
      * @param string|UnitEnum $key Attribute name.
@@ -136,19 +136,16 @@ trait HasContainerCollection
      */
     public function getContainerAttribute(string|UnitEnum $key, mixed $default = null): mixed
     {
-        $normalizedKey = Enum::normalizeValue($key);
-
-        if ($normalizedKey === '' || is_string($normalizedKey) === false) {
-            throw new InvalidArgumentException(
-                Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage($normalizedKey),
-            );
-        }
-
-        return $this->containerAttributes[$normalizedKey] ?? $default;
+        return AttributeBag::get($this->containerAttributes, $key, $default);
     }
 
     /**
      * Returns the `array` of HTML attributes for the container element.
+     *
+     * Usage example:
+     * ```php
+     * $component->getContainerAttributes();
+     * ```
      *
      * @return array Attributes `array` assigned to the container element.
      *
@@ -162,6 +159,11 @@ trait HasContainerCollection
     /**
      * Returns the tag name for the container element.
      *
+     * Usage example:
+     * ```php
+     * $component->getContainerTag();
+     * ```
+     *
      * @return BlockInterface|false Tag name for the container element, or `false` to disable.
      */
     public function getContainerTag(): false|BlockInterface
@@ -171,6 +173,11 @@ trait HasContainerCollection
 
     /**
      * Returns whether the container element should be rendered.
+     *
+     * Usage example:
+     * ```php
+     * $component->isContainer();
+     * ```
      *
      * @return bool `true` if the container element should be rendered, or `false` to skip rendering.
      */

--- a/src/HasContent.php
+++ b/src/HasContent.php
@@ -25,7 +25,7 @@ trait HasContent
      *
      * Usage example:
      * ```php
-     * $component = $component->content('Hello, <World>!');
+     * $component->content('Hello, <World>!');
      * ```
      *
      * @param string|Stringable ...$values Content to be encoded and appended.
@@ -48,7 +48,7 @@ trait HasContent
      *
      * Usage example:
      * ```php
-     * $content = $component->getContent();
+     * $component->getContent();
      * ```
      *
      * @return string Content value assigned to the element. Never `null`.
@@ -63,7 +63,7 @@ trait HasContent
      *
      * Usage example:
      * ```php
-     * $component = $component->html('<strong>Hello, World!</strong>');
+     * $component->html('<strong>Hello, World!</strong>');
      * ```
      *
      * @param string|Stringable ...$values Raw HTML content to be appended.

--- a/src/HasPrefixCollection.php
+++ b/src/HasPrefixCollection.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Mixin;
 
-use InvalidArgumentException;
 use Stringable;
-use UIAwesome\Html\Helper\{CSSClass, Enum};
+use UIAwesome\Html\Helper\{AttributeBag, CSSClass};
 use UIAwesome\Html\Interop\{BlockInterface, InlineInterface, VoidInterface};
-use UIAwesome\Html\Mixin\Exception\Message;
 use UnitEnum;
 
 use function implode;
@@ -43,7 +41,7 @@ trait HasPrefixCollection
      *
      * Usage example:
      * ```php
-     * $prefix = $component->getPrefix();
+     * $component->getPrefix();
      * ```
      *
      * @return string Prefix content string assigned to the element.
@@ -58,7 +56,7 @@ trait HasPrefixCollection
      *
      * Usage example:
      * ```php
-     * $id = $component->getPrefixAttribute('id', 'default-id');
+     * $component->getPrefixAttribute('id', 'default-id');
      * ```
      *
      * @param string|UnitEnum $key Attribute name.
@@ -68,15 +66,7 @@ trait HasPrefixCollection
      */
     public function getPrefixAttribute(string|UnitEnum $key, mixed $default = null): mixed
     {
-        $normalizedKey = Enum::normalizeValue($key);
-
-        if ($normalizedKey === '' || is_string($normalizedKey) === false) {
-            throw new InvalidArgumentException(
-                Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage($normalizedKey),
-            );
-        }
-
-        return $this->prefixAttributes[$normalizedKey] ?? $default;
+        return AttributeBag::get($this->prefixAttributes, $key, $default);
     }
 
     /**
@@ -84,7 +74,7 @@ trait HasPrefixCollection
      *
      * Usage example:
      * ```php
-     * $attributes = $component->getPrefixAttributes();
+     * $component->getPrefixAttributes();
      * ```
      *
      * @return array Attributes `array` assigned to the prefix element.
@@ -101,7 +91,7 @@ trait HasPrefixCollection
      *
      * Usage example:
      * ```php
-     * $tag = $component->getPrefixTag();
+     * $component->getPrefixTag();
      * ```
      *
      * @return BlockInterface|false|InlineInterface|VoidInterface Tag name for the prefix element, or `false` to
@@ -117,7 +107,7 @@ trait HasPrefixCollection
      *
      * Usage example:
      * ```php
-     * $component = $component->prefix('Start ', 'of ', 'element');
+     * $component->prefix('Start ', 'of ', 'element');
      * ```
      *
      * @param string|Stringable ...$values Prefix content to set for the element.
@@ -137,7 +127,7 @@ trait HasPrefixCollection
      *
      * Usage example:
      * ```php
-     * $component = $component->prefixAttributes(['id' => 'prefix-id']);
+     * $component->prefixAttributes(['id' => 'prefix-id']);
      * ```
      *
      * @param array $values Associative array of attribute keys and values.
@@ -149,7 +139,8 @@ trait HasPrefixCollection
     public function prefixAttributes(array $values): static
     {
         $new = clone $this;
-        $new->prefixAttributes = [...$new->prefixAttributes, ...$values];
+
+        AttributeBag::merge($new->prefixAttributes, $values);
 
         return $new;
     }
@@ -159,8 +150,8 @@ trait HasPrefixCollection
      *
      * Usage example:
      * ```php
-     * $component = $component->prefixClass('new-class');
-     * $component = $component->prefixClass('override-class', true);
+     * $component->prefixClass('new-class');
+     * $component->prefixClass('override-class', true);
      * ```
      *
      * @param string|Stringable|UnitEnum $value CSS class name to add.
@@ -171,6 +162,7 @@ trait HasPrefixCollection
     public function prefixClass(string|Stringable|UnitEnum $value, bool $override = false): static
     {
         $new = clone $this;
+
         CSSClass::add($new->prefixAttributes, $value, $override);
 
         return $new;
@@ -181,8 +173,8 @@ trait HasPrefixCollection
      *
      * Usage example:
      * ```php
-     * $component = $component->prefixTag(\UIAwesome\Html\Interop\Inline::SPAN);
-     * $component = $component->prefixTag(false);
+     * $component->prefixTag(\UIAwesome\Html\Interop\Inline::SPAN);
+     * $component->prefixTag(false);
      * ```
      *
      * @param BlockInterface|false|InlineInterface|VoidInterface $value Tag name for the prefix element, or `false` to

--- a/src/HasSuffixCollection.php
+++ b/src/HasSuffixCollection.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Mixin;
 
-use InvalidArgumentException;
 use Stringable;
-use UIAwesome\Html\Helper\{CSSClass, Enum};
+use UIAwesome\Html\Helper\{AttributeBag, CSSClass};
 use UIAwesome\Html\Interop\{BlockInterface, InlineInterface, VoidInterface};
-use UIAwesome\Html\Mixin\Exception\Message;
 use UnitEnum;
 
 use function implode;
@@ -43,7 +41,7 @@ trait HasSuffixCollection
      *
      * Usage example:
      * ```php
-     * $suffix = $component->getSuffix();
+     * $component->getSuffix();
      * ```
      *
      * @return string Suffix content string assigned to the element.
@@ -58,7 +56,7 @@ trait HasSuffixCollection
      *
      * Usage example:
      * ```php
-     * $id = $component->getSuffixAttribute('id', 'default-id');
+     * $component->getSuffixAttribute('id', 'default-id');
      * ```
      *
      * @param string|UnitEnum $key Attribute name.
@@ -68,15 +66,7 @@ trait HasSuffixCollection
      */
     public function getSuffixAttribute(string|UnitEnum $key, mixed $default = null): mixed
     {
-        $normalizedKey = Enum::normalizeValue($key);
-
-        if ($normalizedKey === '' || is_string($normalizedKey) === false) {
-            throw new InvalidArgumentException(
-                Message::KEY_MUST_BE_NON_EMPTY_STRING->getMessage($normalizedKey),
-            );
-        }
-
-        return $this->suffixAttributes[$normalizedKey] ?? $default;
+        return AttributeBag::get($this->suffixAttributes, $key, $default);
     }
 
     /**
@@ -84,7 +74,7 @@ trait HasSuffixCollection
      *
      * Usage example:
      * ```php
-     * $attributes = $component->getSuffixAttributes();
+     * $component->getSuffixAttributes();
      * ```
      *
      * @return array Attributes `array` assigned to the suffix element.
@@ -101,7 +91,7 @@ trait HasSuffixCollection
      *
      * Usage example:
      * ```php
-     * $tag = $component->getSuffixTag();
+     * $component->getSuffixTag();
      * ```
      *
      * @return BlockInterface|false|InlineInterface|VoidInterface Tag name for the suffix element, or `false` to
@@ -117,7 +107,7 @@ trait HasSuffixCollection
      *
      * Usage example:
      * ```php
-     * $component = $component->suffix(' End', ' of ', 'element');
+     * $component->suffix(' End', ' of ', 'element');
      * ```
      *
      * @param string|Stringable ...$values Suffix content to set for the element.
@@ -137,7 +127,7 @@ trait HasSuffixCollection
      *
      * Usage example:
      * ```php
-     * $component = $component->suffixAttributes(['id' => 'suffix-id']);
+     * $component->suffixAttributes(['id' => 'suffix-id']);
      * ```
      *
      * @param array $values Associative array of attribute keys and values.
@@ -149,7 +139,8 @@ trait HasSuffixCollection
     public function suffixAttributes(array $values): static
     {
         $new = clone $this;
-        $new->suffixAttributes = [...$new->suffixAttributes, ...$values];
+
+        AttributeBag::merge($new->suffixAttributes, $values);
 
         return $new;
     }
@@ -159,8 +150,8 @@ trait HasSuffixCollection
      *
      * Usage example:
      * ```php
-     * $component = $component->suffixClass('new-class');
-     * $component = $component->suffixClass('override-class', true);
+     * $component->suffixClass('new-class');
+     * $component->suffixClass('override-class', true);
      * ```
      *
      * @param string|Stringable|UnitEnum $value CSS class name to add.
@@ -171,6 +162,7 @@ trait HasSuffixCollection
     public function suffixClass(string|Stringable|UnitEnum $value, bool $override = false): static
     {
         $new = clone $this;
+
         CSSClass::add($new->suffixAttributes, $value, $override);
 
         return $new;
@@ -181,8 +173,8 @@ trait HasSuffixCollection
      *
      * Usage example:
      * ```php
-     * $component = $component->suffixTag(\UIAwesome\Html\Interop\Inline::SPAN);
-     * $component = $component->suffixTag(false);
+     * $component->suffixTag(\UIAwesome\Html\Interop\Inline::SPAN);
+     * $component->suffixTag(false);
      * ```
      *
      * @param BlockInterface|false|InlineInterface|VoidInterface $value Tag name for the suffix element, or `false` to

--- a/src/HasTemplate.php
+++ b/src/HasTemplate.php
@@ -22,7 +22,7 @@ trait HasTemplate
      *
      * Usage example:
      * ```php
-     * $template = $component->getTemplate();
+     * $component->getTemplate();
      * ```
      *
      * @return string Template value assigned to the element. Never `null`.
@@ -37,7 +37,7 @@ trait HasTemplate
      *
      * Usage example:
      * ```php
-     * $component = $component->template('<div>{content}</div>');
+     * $component->template('<div>{content}</div>');
      * ```
      *
      * @param string $value Template string to set for the element.

--- a/tests/HasAttributesTest.php
+++ b/tests/HasAttributesTest.php
@@ -4,30 +4,22 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Mixin\Tests;
 
-use Closure;
 use InvalidArgumentException;
-use PHPUnit\Framework\Attributes\{DataProviderExternal, Group};
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
-use Stringable;
 use UIAwesome\Html\Mixin\Exception\Message;
 use UIAwesome\Html\Mixin\HasAttributes;
-use UIAwesome\Html\Mixin\Tests\Support\Provider\AttributeProvider;
 use UIAwesome\Html\Mixin\Tests\Support\Stub\Enum\{Priority, Status};
-use UnitEnum;
 
 /**
  * Unit tests for the {@see HasAttributes} trait managing HTML attributes.
  *
  * Test coverage.
- * - Ensures `getAttribute()` returns default values or `null` for missing keys without mutating attributes.
  * - Ensures fluent setters return new instances (immutability).
+ * - Removes attributes and returns expected values.
  * - Sets attributes in bulk and merges new values over existing keys.
- * - Sets prefixed attributes, including closure resolution and null-based removal.
  * - Sets single attributes for scalar and enum keys.
- * - Throws `InvalidArgumentException` for empty or unsupported attribute keys.
- * - Verifies attribute retrieval for existing keys, including enum keys.
- *
- * {@see AttributeProvider} for test case data providers.
+ * - Throws InvalidArgumentException for empty or unsupported attribute keys.
  *
  * @copyright Copyright (C) 2025 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
@@ -35,87 +27,38 @@ use UnitEnum;
 #[Group('mixin')]
 final class HasAttributesTest extends TestCase
 {
-    public function testGetAttributeDoesNotMutateInstance(): void
-    {
-        $instance = new class {
-            use HasAttributes;
-        };
-
-        $instance = $instance->attributes(['id' => 'my-id']);
-        $originalAttributes = $instance->getAttributes();
-
-        $instance->getAttribute('id');
-        $instance->getAttribute('nonexistent', 'default');
-
-        self::assertSame(
-            $originalAttributes,
-            $instance->getAttributes(),
-            'Should return the original attributes array when calling get attribute, ensuring immutability.',
-        );
-    }
-
-    public function testGetAttributeReturnsDefaultWhenAttributeDoesNotExist(): void
-    {
-        $instance = new class {
-            use HasAttributes;
-        };
-
-        self::assertSame(
-            'default-value',
-            $instance->getAttribute('nonexistent', 'default-value'),
-            'Should return the default value when the attribute does not exist.',
-        );
-        self::assertSame(
-            42,
-            $instance->getAttribute('missing', 42),
-            'Should return the default value when the attribute does not exist.',
-        );
-    }
-
-    public function testGetAttributeReturnsNullWhenAttributeDoesNotExist(): void
+    public function testGetAttributeValue(): void
     {
         $instance = new class {
             use HasAttributes;
         };
 
         self::assertNull(
-            $instance->getAttribute('nonexistent'),
-            "Should return 'null' when the attribute does not exist and no default is provided.",
+            $instance->getAttribute('id'),
+            "Should return 'null' when no attributes are set.",
         );
-    }
 
-    public function testGetAttributeReturnsValueWhenAttributeExists(): void
-    {
-        $instance = new class {
-            use HasAttributes;
-        };
-
-        $instance = $instance->attributes(['id' => 'my-id', 'class' => 'my-class']);
+        $instance = $instance->attributes(
+            [
+                'class' => 'my-class',
+                'id' => 'my-id',
+            ],
+        );
 
         self::assertSame(
             'my-id',
             $instance->getAttribute('id'),
-            'Should return the value of the attribute when it exists.',
+            "Should return the correct 'id' attribute after setting it.",
         );
         self::assertSame(
             'my-class',
             $instance->getAttribute('class'),
-            'Should return the value of the attribute when it exists.',
+            "Should return the correct 'class' attribute after setting it.",
         );
-    }
-
-    public function testGetAttributeWithEnumKey(): void
-    {
-        $instance = new class {
-            use HasAttributes;
-        };
-
-        $instance = $instance->addAttribute(Status::ACTIVE, 'active-status');
-
         self::assertSame(
-            'active-status',
-            $instance->getAttribute(Status::ACTIVE),
-            'Should return the value when using an enum key.',
+            'default-value',
+            $instance->getAttribute('missing', 'default-value'),
+            'Should return the default value when the attribute does not exist.',
         );
     }
 
@@ -125,26 +68,18 @@ final class HasAttributesTest extends TestCase
             use HasAttributes;
         };
 
-        $instance = $instance->attributes(['id' => 'my-id', 'class' => 'my-class']);
+        $instance = $instance->attributes(
+            [
+                'class' => 'my-class',
+                'id' => 'my-id',
+            ],
+        );
         $instance = $instance->removeAttribute('id');
 
         self::assertSame(
             ['class' => 'my-class'],
             $instance->getAttributes(),
             'Should return the attributes array after removing an attribute.',
-        );
-    }
-
-    public function testReturnEmptyArrayWhenAttributesNotSet(): void
-    {
-        $instance = new class {
-            use HasAttributes;
-        };
-
-        self::assertSame(
-            [],
-            $instance->getAttributes(),
-            'Should return an empty array when no attributes are set.',
         );
     }
 
@@ -156,7 +91,7 @@ final class HasAttributesTest extends TestCase
 
         self::assertNotSame(
             $instance,
-            $instance->addAttribute('key', 'value'),
+            $instance->addAttribute('tests', ''),
             'Should return a new instance when adding an attribute, ensuring immutability.',
         );
         self::assertNotSame(
@@ -166,28 +101,36 @@ final class HasAttributesTest extends TestCase
         );
         self::assertNotSame(
             $instance,
-            $instance->removeAttribute('key'),
+            $instance->removeAttribute('tests'),
             'Should return a new instance when removing an attribute, ensuring immutability.',
         );
     }
 
-    /**
-     * @phpstan-param mixed[] $attributes
-     * @phpstan-param mixed[] $expected
-     */
-    #[DataProviderExternal(AttributeProvider::class, 'values')]
-    public function testSetAttributesValue(array $attributes, array $expected, string $message): void
+    public function testSetAttributesValue(): void
     {
         $instance = new class {
             use HasAttributes;
         };
 
-        $instance = $instance->attributes($attributes);
+        self::assertEmpty(
+            $instance->getAttributes(),
+            "Should return an empty 'array' when no attributes are set.",
+        );
+
+        $instance = $instance->attributes(
+            [
+                'class' => 'my-class',
+                'id' => 'my-id',
+            ],
+        );
 
         self::assertSame(
-            $expected,
+            [
+                'class' => 'my-class',
+                'id' => 'my-id',
+            ],
             $instance->getAttributes(),
-            $message,
+            'Should return the correct attributes after setting them.',
         );
     }
 
@@ -198,9 +141,7 @@ final class HasAttributesTest extends TestCase
         };
 
         $instance = $instance->attributes(
-            [
-                'id' => 'my-id',
-            ],
+            ['id' => 'my-id'],
         );
         $instance = $instance->attributes(
             [
@@ -219,152 +160,47 @@ final class HasAttributesTest extends TestCase
         );
     }
 
-    public function testSetAttributesWithPrefixValue(): void
+    public function testSetSingleAttributeValue(): void
     {
         $instance = new class {
             use HasAttributes;
-
-            /**
-             * @phpstan-param scalar|null|Closure(): mixed $value
-             */
-            public function addAriaAttribute(
-                string|UnitEnum $key,
-                bool|float|int|string|Closure|Stringable|UnitEnum|null $value,
-            ): static {
-                $new = clone $this;
-
-                $new->setAttribute($key, $value, 'aria-', true);
-
-                return $new;
-            }
         };
 
-        $instance = $instance
-            ->addAriaAttribute('label', 'Label')
-            ->addAriaAttribute('hidden', true);
+        $instance = $instance->addAttribute('id', 'my-id');
 
         self::assertSame(
-            [
-                'aria-label' => 'Label',
-                'aria-hidden' => 'true',
-            ],
+            'my-id',
+            $instance->getAttribute('id'),
+            "Should return the correct 'id' attribute after setting it.",
+        );
+
+        self::assertSame(
+            ['id' => 'my-id'],
             $instance->getAttributes(),
-            'Should set attribute with prefix correctly.',
+            'Should return the correct attributes after setting a single attribute.',
+        );
+
+        $instance = $instance->addAttribute(Status::ACTIVE, 'active-status');
+
+        self::assertSame(
+            'active-status',
+            $instance->getAttribute(Status::ACTIVE),
+            'Should return the value when using an enum key.',
         );
     }
 
-    public function testSetAttributesWithPrefixValueAndBoolStringFalse(): void
+    public function testSetSingleAttributeWithNullValue(): void
     {
         $instance = new class {
             use HasAttributes;
-
-            /**
-             * @phpstan-param scalar|null|Closure(): mixed $value
-             */
-            public function addDataAttribute(
-                string|UnitEnum $key,
-                bool|float|int|string|Closure|Stringable|UnitEnum|null $value,
-            ): static {
-                $new = clone $this;
-
-                $new->setAttribute($key, $value, 'data-');
-
-                return $new;
-            }
         };
 
-        $instance = $instance->addDataAttribute('disabled', true);
+        $instance = $instance->addAttribute('id', 'my-id');
+        $instance = $instance->addAttribute('id', null);
 
-        self::assertSame(
-            ['data-disabled' => true],
-            $instance->getAttributes(),
-            'Should set attribute with prefix correctly.',
-        );
-    }
-
-    public function testSetAttributeWithClosureValue(): void
-    {
-        $instance = new class {
-            use HasAttributes;
-
-            /**
-             * @phpstan-param scalar|null|Closure(): mixed $value
-             */
-            public function addDataAttribute(
-                string|UnitEnum $key,
-                bool|float|int|string|Closure|Stringable|UnitEnum|null $value,
-            ): static {
-                $new = clone $this;
-
-                $new->setAttribute($key, $value, 'data-');
-
-                return $new;
-            }
-        };
-
-        $closure = static fn(): string => 'resolved-value';
-        $instance = $instance->addDataAttribute('test', $closure);
-
-        self::assertSame(
-            ['data-test' => 'resolved-value'],
-            $instance->getAttributes(),
-            'Should execute the closure and set the resolved value as the attribute value.',
-        );
-    }
-
-    public function testSetAttributeWithNullValueRemovesAttribute(): void
-    {
-        $instance = new class {
-            use HasAttributes;
-
-            /**
-             * @phpstan-param scalar|null|Closure(): mixed $value
-             */
-            public function addAriaAttribute(
-                string|UnitEnum $key,
-                bool|float|int|string|Closure|Stringable|UnitEnum|null $value,
-            ): static {
-                $new = clone $this;
-
-                $new->setAttribute($key, $value, 'aria-', true);
-
-                return $new;
-            }
-        };
-
-        $instance = $instance
-            ->addAriaAttribute('label', 'Label')
-            ->addAriaAttribute('hidden', true)
-            ->addAriaAttribute('label', null);
-
-        self::assertSame(
-            ['aria-hidden' => 'true'],
-            $instance->getAttributes(),
-            'Should remove the attribute when null value is provided via setAttribute.',
-        );
-    }
-
-    /**
-     * @phpstan-param scalar|null|Closure(): mixed $value
-     * @phpstan-param mixed[] $expected
-     */
-    #[DataProviderExternal(AttributeProvider::class, 'value')]
-    public function testSetSingleAttributeValue(
-        string|UnitEnum $key,
-        bool|float|int|string|Closure|null $value,
-        array $expected,
-        string $message,
-    ): void {
-        $instance = new class {
-            use HasAttributes;
-        };
-
-        $instance = $instance->addAttribute($key, $value);
-
-        self::assertSame(
-            $expected,
-            $instance->getAttributes(),
-            $message,
+        self::assertNull(
+            $instance->getAttribute('id'),
+            "Should return 'null' after setting the attribute to 'null'.",
         );
     }
 

--- a/tests/HasContainerCollectionTest.php
+++ b/tests/HasContainerCollectionTest.php
@@ -17,11 +17,12 @@ use UIAwesome\Html\Mixin\Tests\Support\Stub\Enum\Priority;
  *
  * Test coverage.
  * - Ensures fluent setters return new instances (immutability).
- * - Merges new attributes with existing ones, overriding duplicates.
- * - Sets the container attributes.
- * - Sets the container rendering flag.
- * - Sets the container tag.
- * - Throws `InvalidArgumentException` for empty or unsupported container attribute keys.
+ * - Merges new container attributes with existing attributes and overrides duplicate keys.
+ * - Sets container attributes and returns expected values.
+ * - Sets container CSS classes, including merged and overridden values.
+ * - Sets container tag values and supports disabling the tag.
+ * - Throws InvalidArgumentException for empty or unsupported container attribute keys.
+ * - Verifies container rendering state after enabling and disabling it.
  *
  * @copyright Copyright (C) 2026 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
@@ -29,7 +30,42 @@ use UIAwesome\Html\Mixin\Tests\Support\Stub\Enum\Priority;
 #[Group('mixin')]
 final class HasContainerCollectionTest extends TestCase
 {
-    public function testReturnNewInstanceWhenSettingContainer(): void
+    public function testGetContainerAttributeValue(): void
+    {
+        $instance = new class {
+            use HasContainerCollection;
+        };
+
+        self::assertNull(
+            $instance->getContainerAttribute('id'),
+            "Should return 'null' when no attributes are set.",
+        );
+
+        $instance = $instance->containerAttributes(
+            [
+                'class' => 'container-class',
+                'id' => 'container-id',
+            ],
+        );
+
+        self::assertSame(
+            'container-id',
+            $instance->getContainerAttribute('id'),
+            "Should return the correct 'id' attribute after setting it.",
+        );
+        self::assertSame(
+            'container-class',
+            $instance->getContainerAttribute('class'),
+            "Should return the correct 'class' attribute after setting it.",
+        );
+        self::assertSame(
+            'default-value',
+            $instance->getContainerAttribute('missing', 'default-value'),
+            'Should return the default value when the container attribute does not exist.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingContainerCollection(): void
     {
         $instance = new class {
             use HasContainerCollection;
@@ -48,37 +84,11 @@ final class HasContainerCollectionTest extends TestCase
         self::assertNotSame(
             $instance,
             $instance->containerClass(''),
-            'Should return a new instance when setting the container class, ensuring immutability.',
+            "Should return a new instance when setting the container 'class' attribute, ensuring immutability.",
         );
         self::assertNotSame(
             $instance,
             $instance->containerTag(false),
-            'Should return a new instance when setting the container tag, ensuring immutability.',
-        );
-    }
-
-    public function testReturnNewInstanceWhenSettingContainerAttributes(): void
-    {
-        $instance = new class {
-            use HasContainerCollection;
-        };
-
-        self::assertNotSame(
-            $instance,
-            $instance->containerAttributes([]),
-            'Should return a new instance when setting the container attributes, ensuring immutability.',
-        );
-    }
-
-    public function testReturnNewInstanceWhenSettingContainerTag(): void
-    {
-        $instance = new class {
-            use HasContainerCollection;
-        };
-
-        self::assertNotSame(
-            $instance,
-            $instance->containerTag(Block::DIV),
             'Should return a new instance when setting the container tag, ensuring immutability.',
         );
     }
@@ -91,7 +101,7 @@ final class HasContainerCollectionTest extends TestCase
 
         self::assertEmpty(
             $instance->getContainerAttributes(),
-            'Should return an empty array when no attributes are set.',
+            "Should return an empty 'array' when no attributes are set.",
         );
 
         $instance = $instance->containerAttributes(
@@ -147,7 +157,7 @@ final class HasContainerCollectionTest extends TestCase
 
         self::assertEmpty(
             $instance->getContainerAttributes(),
-            'Should return an empty array when no attributes are set.',
+            "Should return an empty 'array' when no attributes are set.",
         );
 
         $instance = $instance->containerClass('container-class');
@@ -155,7 +165,7 @@ final class HasContainerCollectionTest extends TestCase
         self::assertSame(
             'container-class',
             $instance->getContainerAttribute('class', ''),
-            'Should return the correct container class after setting it.',
+            "Should return the correct container 'class' attribute after setting it.",
         );
 
         $instance = $instance->containerClass('container-class-1');
@@ -163,7 +173,7 @@ final class HasContainerCollectionTest extends TestCase
         self::assertSame(
             'container-class container-class-1',
             $instance->getContainerAttribute('class', ''),
-            'Should return the correct container class after setting it.',
+            "Should return the correct container 'class' attribute after setting it.",
         );
 
         $instance = $instance->containerClass('override-class', true);
@@ -171,7 +181,22 @@ final class HasContainerCollectionTest extends TestCase
         self::assertSame(
             'override-class',
             $instance->getContainerAttribute('class', ''),
-            'Should return the correct container class after setting it.',
+            "Should return the correct container 'class' attribute after setting it.",
+        );
+    }
+
+    public function testSetContainerTagFalseValue(): void
+    {
+        $instance = new class {
+            use HasContainerCollection;
+        };
+
+        $instance = $instance->containerTag(Block::SECTION);
+        $instance = $instance->containerTag(false);
+
+        self::assertFalse(
+            $instance->getContainerTag(),
+            "Should return 'false' after setting the container tag to 'false'.",
         );
     }
 
@@ -183,7 +208,7 @@ final class HasContainerCollectionTest extends TestCase
 
         self::assertFalse(
             $instance->getContainerTag(),
-            'Should return false when no tag is set.',
+            "Should return 'false' when no tag is set.",
         );
 
         $instance = $instance->containerTag(Block::SECTION);
@@ -203,21 +228,21 @@ final class HasContainerCollectionTest extends TestCase
 
         self::assertFalse(
             $instance->isContainer(),
-            'Should return false when container is not set.',
+            "Should return 'false' when container is not set.",
         );
 
         $instance = $instance->container(true);
 
         self::assertTrue(
             $instance->isContainer(),
-            'Should return true after setting container to true.',
+            "Should return 'true' after setting container to 'true'.",
         );
 
         $instance = $instance->container(false);
 
         self::assertFalse(
             $instance->isContainer(),
-            'Should return false after setting container to false.',
+            "Should return 'false' after setting container to 'false'.",
         );
     }
 

--- a/tests/HasContentTest.php
+++ b/tests/HasContentTest.php
@@ -53,7 +53,7 @@ final class HasContentTest extends TestCase
         self::assertSame(
             '',
             $instance->getContent(),
-            'Should return an empty string when no content is set.',
+            "Should return an empty 'string' when no content is set.",
         );
     }
 
@@ -95,7 +95,7 @@ final class HasContentTest extends TestCase
         self::assertSame(
             '&lt;script&gt;alert("xss")&lt;/script&gt;',
             $instance->getContent(),
-            'Should encode special characters when using content().',
+            "Should encode special characters when using 'content()'.",
         );
     }
 
@@ -111,7 +111,7 @@ final class HasContentTest extends TestCase
         self::assertSame(
             '<span>Raw Content</span>',
             $instance->getContent(),
-            'Should NOT encode characters when using html(), allowing raw markup.',
+            "Should NOT encode characters when using 'html()', allowing raw markup.",
         );
     }
 
@@ -127,7 +127,7 @@ final class HasContentTest extends TestCase
         self::assertSame(
             'OneTwoThreeFourFive',
             $instance->getContent(),
-            'Should handle variadic parameters correctly for both content() and html().',
+            "Should handle variadic parameters correctly for both 'content()' and 'html()'.",
         );
     }
 }

--- a/tests/HasLabelCollectionTest.php
+++ b/tests/HasLabelCollectionTest.php
@@ -21,7 +21,7 @@ use UIAwesome\Html\Mixin\Tests\Support\Stub\Enum\Priority;
  * - Sets label CSS classes, including merged and overridden values.
  * - Sets label for attribute and returns expected value.
  * - Sets label text content and returns the expected value.
- * - Throws `InvalidArgumentException` for empty or unsupported attribute keys.
+ * - Throws InvalidArgumentException for empty or unsupported attribute keys.
  * - Verifies label rendering state after setting content and disabling rendering.
  *
  * @copyright Copyright (C) 2026 Terabytesoftw.
@@ -97,12 +97,12 @@ final class HasLabelCollectionTest extends TestCase
         self::assertNotSame(
             $instance,
             $instance->labelClass(''),
-            'Should return a new instance when setting the label class, ensuring immutability.',
+            "Should return a new instance when setting the label 'class' attribute, ensuring immutability.",
         );
         self::assertNotSame(
             $instance,
             $instance->labelFor('for'),
-            'Should return a new instance when setting the label for attribute, ensuring immutability.',
+            "Should return a new instance when setting the label 'for' attribute, ensuring immutability.",
         );
         self::assertNotSame(
             $instance,

--- a/tests/HasPrefixCollectionTest.php
+++ b/tests/HasPrefixCollectionTest.php
@@ -51,12 +51,12 @@ final class HasPrefixCollectionTest extends TestCase
         self::assertSame(
             'prefix-id',
             $instance->getPrefixAttribute('id'),
-            "Should return the correct 'id' attribute prefix attribute after setting it.",
+            "Should return the correct 'id' attribute after setting it.",
         );
         self::assertSame(
             'prefix-class',
             $instance->getPrefixAttribute('class'),
-            "Should return the correct 'class' attribute prefix attribute after setting it.",
+            "Should return the correct 'class' attribute after setting it.",
         );
         self::assertSame(
             'default-value',

--- a/tests/HasPrefixCollectionTest.php
+++ b/tests/HasPrefixCollectionTest.php
@@ -7,7 +7,6 @@ namespace UIAwesome\Html\Mixin\Tests;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
-use Stringable;
 use UIAwesome\Html\Interop\Inline;
 use UIAwesome\Html\Mixin\Exception\Message;
 use UIAwesome\Html\Mixin\HasPrefixCollection;
@@ -19,11 +18,11 @@ use UIAwesome\Html\Mixin\Tests\Support\Stub\Enum\Priority;
  * Test coverage.
  * - Ensures fluent setters return new instances (immutability).
  * - Merges new prefix attributes with existing ones, overriding duplicates.
- * - Sets the prefix attributes.
- * - Sets the prefix class, including class override behavior.
- * - Sets the prefix tag and supports resetting it to `false`.
- * - Sets the prefix value from strings, variadic parts, and `Stringable` objects.
- * - Throws `InvalidArgumentException` for empty or unsupported prefix attribute keys.
+ * - Sets prefix attributes and returns expected values.
+ * - Sets prefix CSS classes, including merged and overridden values.
+ * - Sets prefix tag values and supports disabling the tag.
+ * - Sets prefix text content and returns the expected value.
+ * - Throws InvalidArgumentException for empty or unsupported prefix attribute keys.
  *
  * @copyright Copyright (C) 2025 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
@@ -31,7 +30,42 @@ use UIAwesome\Html\Mixin\Tests\Support\Stub\Enum\Priority;
 #[Group('mixin')]
 final class HasPrefixCollectionTest extends TestCase
 {
-    public function testReturnNewInstanceWhenSettingAttributes(): void
+    public function testGetPrefixAttributeValue(): void
+    {
+        $instance = new class {
+            use HasPrefixCollection;
+        };
+
+        self::assertNull(
+            $instance->getPrefixAttribute('id'),
+            "Should return 'null' when no attributes are set.",
+        );
+
+        $instance = $instance->prefixAttributes(
+            [
+                'class' => 'prefix-class',
+                'id' => 'prefix-id',
+            ],
+        );
+
+        self::assertSame(
+            'prefix-id',
+            $instance->getPrefixAttribute('id'),
+            "Should return the correct 'id' attribute prefix attribute after setting it.",
+        );
+        self::assertSame(
+            'prefix-class',
+            $instance->getPrefixAttribute('class'),
+            "Should return the correct 'class' attribute prefix attribute after setting it.",
+        );
+        self::assertSame(
+            'default-value',
+            $instance->getPrefixAttribute('missing', 'default-value'),
+            'Should return the default value when the prefix attribute does not exist.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingPrefixCollection(): void
     {
         $instance = new class {
             use HasPrefixCollection;
@@ -50,7 +84,7 @@ final class HasPrefixCollectionTest extends TestCase
         self::assertNotSame(
             $instance,
             $instance->prefixClass('class-name'),
-            'Should return a new instance when setting the prefix class, ensuring immutability.',
+            "Should return a new instance when setting the prefix 'class' attribute, ensuring immutability.",
         );
         self::assertNotSame(
             $instance,
@@ -67,7 +101,7 @@ final class HasPrefixCollectionTest extends TestCase
 
         self::assertEmpty(
             $instance->getPrefixAttributes(),
-            'Should return an empty array when no attributes are set.',
+            "Should return an empty 'array' when no attributes are set.",
         );
 
         $instance = $instance->prefixAttributes(
@@ -123,7 +157,7 @@ final class HasPrefixCollectionTest extends TestCase
 
         self::assertEmpty(
             $instance->getPrefixAttributes(),
-            'Should return an empty array when no attributes are set.',
+            "Should return an empty 'array' when no attributes are set.",
         );
 
         $instance = $instance->prefixClass('prefix-class');
@@ -131,7 +165,7 @@ final class HasPrefixCollectionTest extends TestCase
         self::assertSame(
             'prefix-class',
             $instance->getPrefixAttribute('class', ''),
-            'Should return the correct prefix class after setting it.',
+            "Should return the correct prefix 'class' attribute after setting it.",
         );
 
         $instance = $instance->prefixClass('prefix-class-1');
@@ -139,7 +173,7 @@ final class HasPrefixCollectionTest extends TestCase
         self::assertSame(
             'prefix-class prefix-class-1',
             $instance->getPrefixAttribute('class', ''),
-            'Should return the correct prefix class after setting it.',
+            "Should return the correct prefix 'class' attribute after setting it.",
         );
 
         $instance = $instance->prefixClass('override-class', true);
@@ -147,7 +181,22 @@ final class HasPrefixCollectionTest extends TestCase
         self::assertSame(
             'override-class',
             $instance->getPrefixAttribute('class', ''),
-            'Should return the correct prefix class after setting it.',
+            "Should return the correct prefix 'class' attribute after setting it.",
+        );
+    }
+
+    public function testSetPrefixTagFalseValue(): void
+    {
+        $instance = new class {
+            use HasPrefixCollection;
+        };
+
+        $instance = $instance->prefixTag(Inline::MARK);
+        $instance = $instance->prefixTag(false);
+
+        self::assertFalse(
+            $instance->getPrefixTag(),
+            "Should return 'false' after setting the prefix tag to 'false'.",
         );
     }
 
@@ -159,7 +208,7 @@ final class HasPrefixCollectionTest extends TestCase
 
         self::assertFalse(
             $instance->getPrefixTag(),
-            'Should return false when no tag is set.',
+            "Should return 'false' when no tag is set.",
         );
 
         $instance = $instance->prefixTag(Inline::MARK);
@@ -168,13 +217,6 @@ final class HasPrefixCollectionTest extends TestCase
             Inline::MARK,
             $instance->getPrefixTag(),
             'Should return the correct prefix tag after setting it.',
-        );
-
-        $instance = $instance->prefixTag(false);
-
-        self::assertFalse(
-            $instance->getPrefixTag(),
-            "Should return 'false' after resetting the prefix tag.",
         );
     }
 
@@ -186,7 +228,7 @@ final class HasPrefixCollectionTest extends TestCase
 
         self::assertEmpty(
             $instance->getPrefix(),
-            'Should return an empty string when no prefix is set.',
+            "Should return an empty 'string' when no prefix is set.",
         );
 
         $instance = $instance->prefix('Prefix content');
@@ -195,43 +237,6 @@ final class HasPrefixCollectionTest extends TestCase
             'Prefix content',
             $instance->getPrefix(),
             'Should return the correct prefix after setting it.',
-        );
-    }
-
-    public function testSetPrefixValueWithMultipleArguments(): void
-    {
-        $instance = new class {
-            use HasPrefixCollection;
-        };
-
-        $instance = $instance->prefix('Prefix', ' ', 'content');
-
-        self::assertSame(
-            'Prefix content',
-            $instance->getPrefix(),
-            'Should concatenate multiple prefix arguments.',
-        );
-    }
-
-    public function testSetPrefixValueWithStringable(): void
-    {
-        $instance = new class {
-            use HasPrefixCollection;
-        };
-
-        $stringable = new class implements Stringable {
-            public function __toString(): string
-            {
-                return 'Stringable content';
-            }
-        };
-
-        $instance = $instance->prefix($stringable);
-
-        self::assertSame(
-            'Stringable content',
-            $instance->getPrefix(),
-            'Should handle Stringable objects correctly.',
         );
     }
 

--- a/tests/HasSuffixCollectionTest.php
+++ b/tests/HasSuffixCollectionTest.php
@@ -186,6 +186,22 @@ final class HasSuffixCollectionTest extends TestCase
         );
     }
 
+    public function testSetSuffixTagFalseValue(): void
+    {
+        $instance = new class {
+            use HasSuffixCollection;
+        };
+
+        $instance = $instance->suffixTag(Block::DIV);
+
+        $instance = $instance->suffixTag(false);
+
+        self::assertFalse(
+            $instance->getSuffixTag(),
+            "Should return 'false' after setting the suffix tag to 'false'.",
+        );
+    }
+
     public function testSetSuffixTagValue(): void
     {
         $instance = new class {
@@ -203,22 +219,6 @@ final class HasSuffixCollectionTest extends TestCase
             Block::DIV,
             $instance->getSuffixTag(),
             'Should return the correct suffix tag after setting it.',
-        );
-    }
-
-    public function testSetSuffixTagFalseValue(): void
-    {
-        $instance = new class {
-            use HasSuffixCollection;
-        };
-
-        $instance = $instance->suffixTag(Block::DIV);
-
-        $instance = $instance->suffixTag(false);
-
-        self::assertFalse(
-            $instance->getSuffixTag(),
-            "Should return 'false' after setting the suffix tag to 'false'.",
         );
     }
 

--- a/tests/HasSuffixCollectionTest.php
+++ b/tests/HasSuffixCollectionTest.php
@@ -23,7 +23,7 @@ use UIAwesome\Html\Mixin\Tests\Support\Stub\Enum\Priority;
  * - Sets the suffix class, including class override behavior.
  * - Sets the suffix tag and supports resetting it to `false`.
  * - Sets the suffix value from strings, variadic parts, and `Stringable` objects.
- * - Throws `InvalidArgumentException` for empty or unsupported suffix attribute keys.
+ * - Throws InvalidArgumentException for empty or unsupported suffix attribute keys.
  *
  * @copyright Copyright (C) 2025 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
@@ -31,7 +31,42 @@ use UIAwesome\Html\Mixin\Tests\Support\Stub\Enum\Priority;
 #[Group('mixin')]
 final class HasSuffixCollectionTest extends TestCase
 {
-    public function testReturnNewInstanceWhenSettingAttributes(): void
+    public function testGetSuffixAttributeValue(): void
+    {
+        $instance = new class {
+            use HasSuffixCollection;
+        };
+
+        self::assertNull(
+            $instance->getSuffixAttribute('id'),
+            "Should return 'null' when no attributes are set.",
+        );
+
+        $instance = $instance->suffixAttributes(
+            [
+                'class' => 'suffix-class',
+                'id' => 'suffix-id',
+            ],
+        );
+
+        self::assertSame(
+            'suffix-id',
+            $instance->getSuffixAttribute('id'),
+            "Should return the correct 'id' attribute after setting it.",
+        );
+        self::assertSame(
+            'suffix-class',
+            $instance->getSuffixAttribute('class'),
+            "Should return the correct 'class' attribute after setting it.",
+        );
+        self::assertSame(
+            'default-value',
+            $instance->getSuffixAttribute('missing', 'default-value'),
+            'Should return the default value when the suffix attribute does not exist.',
+        );
+    }
+
+    public function testReturnNewInstanceWhenSettingSuffixCollection(): void
     {
         $instance = new class {
             use HasSuffixCollection;
@@ -159,7 +194,7 @@ final class HasSuffixCollectionTest extends TestCase
 
         self::assertFalse(
             $instance->getSuffixTag(),
-            'Should return false when no tag is set.',
+            "Should return 'false' when no tag is set.",
         );
 
         $instance = $instance->suffixTag(Block::DIV);
@@ -169,12 +204,21 @@ final class HasSuffixCollectionTest extends TestCase
             $instance->getSuffixTag(),
             'Should return the correct suffix tag after setting it.',
         );
+    }
+
+    public function testSetSuffixTagFalseValue(): void
+    {
+        $instance = new class {
+            use HasSuffixCollection;
+        };
+
+        $instance = $instance->suffixTag(Block::DIV);
 
         $instance = $instance->suffixTag(false);
 
         self::assertFalse(
             $instance->getSuffixTag(),
-            "Should return 'false' after resetting the suffix tag.",
+            "Should return 'false' after setting the suffix tag to 'false'.",
         );
     }
 

--- a/tests/HasTemplateTest.php
+++ b/tests/HasTemplateTest.php
@@ -31,7 +31,7 @@ final class HasTemplateTest extends TestCase
         self::assertSame(
             '',
             $instance->getTemplate(),
-            'Should return an empty string when no template is set.',
+            "Should return an empty 'string' when no template is set.",
         );
     }
 


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
