### PR TITLE
feat(mixin): Add `setAttribute()` prefixed attribute APIs to `HasContainerCollection`, `HasLabelCollection`, `HasPrefixCollection`, and `HasSuffixCollection` and related tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.3.7 Under development
 
+- Enh #54: Add `setAttribute()` prefixed attribute APIs to `HasContainerCollection`, `HasLabelCollection`, `HasPrefixCollection`, and `HasSuffixCollection` and related tests (@terabytesoftw)
+
 ## 0.3.6 February 14, 2026
 
 - Enh #51: Add `HasLabelCollection` mixin for managing label tag and attributes (@terabytesoftw)

--- a/src/HasAttributes.php
+++ b/src/HasAttributes.php
@@ -144,7 +144,7 @@ trait HasAttributes
      *
      * @return static New instance with the updated `attributes` value.
      *
-     * @phpstan-param scalar|Stringable|UnitEnum|Closure(): mixed $value
+     * @phpstan-param scalar|Closure(): mixed|Stringable|UnitEnum|null $value
      */
     public function setAttribute(
         string|UnitEnum $key,

--- a/src/HasAttributes.php
+++ b/src/HasAttributes.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Mixin;
 
+use Closure;
+use Stringable;
 use UIAwesome\Html\Helper\AttributeBag;
 use UnitEnum;
 
@@ -127,6 +129,32 @@ trait HasAttributes
         $new = clone $this;
 
         AttributeBag::remove($new->attributes, $key);
+
+        return $new;
+    }
+
+    /**
+     * Sets a single attribute with prefix handling and value resolution.
+     *
+     * @param string|UnitEnum $key Attribute key (without the prefix if a prefix is supplied).
+     * @param bool|Closure|float|int|string|Stringable|UnitEnum|null $value Attribute value, or `null` to remove the
+     * attribute.
+     * @param string $prefix Optional prefix to prepend to the key (for example, `aria-`, `data-`, `on-`).
+     * @param bool $boolToString Whether to convert boolean values to `true` and `false` strings.
+     *
+     * @return static New instance with the updated `attributes` value.
+     *
+     * @phpstan-param scalar|Stringable|UnitEnum|Closure(): mixed $value
+     */
+    public function setAttribute(
+        string|UnitEnum $key,
+        bool|float|int|string|Closure|Stringable|UnitEnum|null $value,
+        string $prefix = '',
+        bool $boolToString = false,
+    ): static {
+        $new = clone $this;
+
+        AttributeBag::set($new->attributes, $key, $value, $prefix, $boolToString);
 
         return $new;
     }

--- a/src/HasContainerCollection.php
+++ b/src/HasContainerCollection.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Mixin;
 
+use Closure;
 use Stringable;
 use UIAwesome\Html\Helper\{AttributeBag, CSSClass};
 use UIAwesome\Html\Interop\BlockInterface;
@@ -33,6 +34,29 @@ trait HasContainerCollection
      * Tag name for the container element, or `false` to disable.
      */
     protected false|BlockInterface $containerTag = false;
+
+    /**
+     * Sets a single HTML attribute for the container element.
+     *
+     * Usage example:
+     * ```php
+     * $component->addContainerAttribute('id', 'my-id');
+     * $component->addContainerAttribute('id', null);
+     * ```
+     *
+     * @param string|UnitEnum $key Attribute name.
+     * @param mixed $value Attribute value.
+     *
+     * @return static New instance with the updated `containerAttributes` value.
+     */
+    public function addContainerAttribute(string|UnitEnum $key, mixed $value): static
+    {
+        $new = clone $this;
+
+        AttributeBag::add($new->containerAttributes, $key, $value);
+
+        return $new;
+    }
 
     /**
      * Sets whether to render the container.
@@ -184,5 +208,58 @@ trait HasContainerCollection
     public function isContainer(): bool
     {
         return $this->container;
+    }
+
+    /**
+     * Removes a specific HTML attribute from the container element.
+     *
+     * Usage example:
+     * ```php
+     * $component->removeContainerAttribute('id');
+     * ```
+     *
+     * @param string|UnitEnum $key Attribute name to remove.
+     *
+     * @return static New instance without the specified container attribute.
+     */
+    public function removeContainerAttribute(string|UnitEnum $key): static
+    {
+        $new = clone $this;
+
+        AttributeBag::remove($new->containerAttributes, $key);
+
+        return $new;
+    }
+
+    /**
+     * Sets a single attribute with prefix handling and value resolution for the container element.
+     *
+     * Usage example:
+     * ```php
+     * $component->setContainerAttribute('label', 'Label', 'aria-');
+     * $component->setContainerAttribute('hidden', true, 'aria-', true);
+     * ```
+     *
+     * @param string|UnitEnum $key Attribute key without prefix.
+     * @param bool|Closure|float|int|string|Stringable|UnitEnum|null $value Attribute value, or `null` to remove the
+     * attribute.
+     * @param string $prefix Prefix to prepend to the key.
+     * @param bool $boolToString Whether to convert booleans to `true` and `false` strings.
+     *
+     * @return static New instance with the updated `containerAttributes` value.
+     *
+     * @phpstan-param scalar|Stringable|UnitEnum|Closure(): mixed $value
+     */
+    public function setContainerAttribute(
+        string|UnitEnum $key,
+        bool|float|int|string|Closure|Stringable|UnitEnum|null $value,
+        string $prefix = '',
+        bool $boolToString = false,
+    ): static {
+        $new = clone $this;
+
+        AttributeBag::set($new->containerAttributes, $key, $value, $prefix, $boolToString);
+
+        return $new;
     }
 }

--- a/src/HasContainerCollection.php
+++ b/src/HasContainerCollection.php
@@ -248,7 +248,7 @@ trait HasContainerCollection
      *
      * @return static New instance with the updated `containerAttributes` value.
      *
-     * @phpstan-param scalar|Stringable|UnitEnum|Closure(): mixed $value
+     * @phpstan-param scalar|Closure(): mixed|Stringable|UnitEnum|null $value
      */
     public function setContainerAttribute(
         string|UnitEnum $key,

--- a/src/HasLabelCollection.php
+++ b/src/HasLabelCollection.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Mixin;
 
+use Closure;
 use Stringable;
 use UIAwesome\Html\Helper\{AttributeBag, CSSClass};
 use UnitEnum;
@@ -34,6 +35,29 @@ trait HasLabelCollection
      * Whether to render the label.
      */
     private bool $notLabel = false;
+
+    /**
+     * Sets a single HTML attribute for the label element.
+     *
+     * Usage example:
+     * ```php
+     * $component->addLabelAttribute('id', 'my-id');
+     * $component->addLabelAttribute('id', null);
+     * ```
+     *
+     * @param string|UnitEnum $key Attribute name.
+     * @param mixed $value Attribute value.
+     *
+     * @return static New instance with the updated `labelAttributes` value.
+     */
+    public function addLabelAttribute(string|UnitEnum $key, mixed $value): static
+    {
+        $new = clone $this;
+
+        AttributeBag::add($new->labelAttributes, $key, $value);
+
+        return $new;
+    }
 
     /**
      * Returns the label content.
@@ -232,6 +256,38 @@ trait HasLabelCollection
         $new = clone $this;
 
         AttributeBag::remove($new->labelAttributes, $key);
+
+        return $new;
+    }
+
+    /**
+     * Sets a single attribute with prefix handling and value resolution for the label element.
+     *
+     * Usage example:
+     * ```php
+     * $component->setLabelAttribute('label', 'Label', 'aria-');
+     * $component->setLabelAttribute('hidden', true, 'aria-', true);
+     * ```
+     *
+     * @param string|UnitEnum $key Attribute key without prefix.
+     * @param bool|Closure|float|int|string|Stringable|UnitEnum|null $value Attribute value, or `null` to remove the
+     * attribute.
+     * @param string $prefix Prefix to prepend to the key.
+     * @param bool $boolToString Whether to convert booleans to `true` and `false` strings.
+     *
+     * @return static New instance with the updated `labelAttributes` value.
+     *
+     * @phpstan-param scalar|Stringable|UnitEnum|Closure(): mixed $value
+     */
+    public function setLabelAttribute(
+        string|UnitEnum $key,
+        bool|float|int|string|Closure|Stringable|UnitEnum|null $value,
+        string $prefix = '',
+        bool $boolToString = false,
+    ): static {
+        $new = clone $this;
+
+        AttributeBag::set($new->labelAttributes, $key, $value, $prefix, $boolToString);
 
         return $new;
     }

--- a/src/HasLabelCollection.php
+++ b/src/HasLabelCollection.php
@@ -277,7 +277,7 @@ trait HasLabelCollection
      *
      * @return static New instance with the updated `labelAttributes` value.
      *
-     * @phpstan-param scalar|Stringable|UnitEnum|Closure(): mixed $value
+     * @phpstan-param scalar|Closure(): mixed|Stringable|UnitEnum|null $value
      */
     public function setLabelAttribute(
         string|UnitEnum $key,

--- a/src/HasPrefixCollection.php
+++ b/src/HasPrefixCollection.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Mixin;
 
+use Closure;
 use Stringable;
 use UIAwesome\Html\Helper\{AttributeBag, CSSClass};
 use UIAwesome\Html\Interop\{BlockInterface, InlineInterface, VoidInterface};
@@ -35,6 +36,29 @@ trait HasPrefixCollection
      * Tag name for the prefix element, or `false` to disable.
      */
     protected false|BlockInterface|InlineInterface|VoidInterface $prefixTag = false;
+
+    /**
+     * Sets a single HTML attribute for the prefix element.
+     *
+     * Usage example:
+     * ```php
+     * $component->addPrefixAttribute('id', 'my-id');
+     * $component->addPrefixAttribute('id', null);
+     * ```
+     *
+     * @param string|UnitEnum $key Attribute name.
+     * @param mixed $value Attribute value.
+     *
+     * @return static New instance with the updated `prefixAttributes` value.
+     */
+    public function addPrefixAttribute(string|UnitEnum $key, mixed $value): static
+    {
+        $new = clone $this;
+
+        AttributeBag::add($new->prefixAttributes, $key, $value);
+
+        return $new;
+    }
 
     /**
      * Returns the prefix content string assigned to the element.
@@ -186,6 +210,59 @@ trait HasPrefixCollection
     {
         $new = clone $this;
         $new->prefixTag = $value;
+
+        return $new;
+    }
+
+    /**
+     * Removes a specific HTML attribute from the prefix element.
+     *
+     * Usage example:
+     * ```php
+     * $component->removePrefixAttribute('id');
+     * ```
+     *
+     * @param string|UnitEnum $key Attribute name to remove.
+     *
+     * @return static New instance without the specified prefix attribute.
+     */
+    public function removePrefixAttribute(string|UnitEnum $key): static
+    {
+        $new = clone $this;
+
+        AttributeBag::remove($new->prefixAttributes, $key);
+
+        return $new;
+    }
+
+    /**
+     * Sets a single attribute with prefix handling and value resolution for the prefix element.
+     *
+     * Usage example:
+     * ```php
+     * $component->setPrefixAttribute('label', 'Label', 'aria-');
+     * $component->setPrefixAttribute('hidden', true, 'aria-', true);
+     * ```
+     *
+     * @param string|UnitEnum $key Attribute key without prefix.
+     * @param bool|Closure|float|int|string|Stringable|UnitEnum|null $value Attribute value, or `null` to remove the
+     * attribute.
+     * @param string $prefix Prefix to prepend to the key.
+     * @param bool $boolToString Whether to convert booleans to `true` and `false` strings.
+     *
+     * @return static New instance with the updated `prefixAttributes` value.
+     *
+     * @phpstan-param scalar|Stringable|UnitEnum|Closure(): mixed $value
+     */
+    public function setPrefixAttribute(
+        string|UnitEnum $key,
+        bool|float|int|string|Closure|Stringable|UnitEnum|null $value,
+        string $prefix = '',
+        bool $boolToString = false,
+    ): static {
+        $new = clone $this;
+
+        AttributeBag::set($new->prefixAttributes, $key, $value, $prefix, $boolToString);
 
         return $new;
     }

--- a/src/HasPrefixCollection.php
+++ b/src/HasPrefixCollection.php
@@ -252,7 +252,7 @@ trait HasPrefixCollection
      *
      * @return static New instance with the updated `prefixAttributes` value.
      *
-     * @phpstan-param scalar|Stringable|UnitEnum|Closure(): mixed $value
+     * @phpstan-param scalar|Closure(): mixed|Stringable|UnitEnum|null $value
      */
     public function setPrefixAttribute(
         string|UnitEnum $key,

--- a/src/HasSuffixCollection.php
+++ b/src/HasSuffixCollection.php
@@ -164,7 +164,7 @@ trait HasSuffixCollection
      *
      * @return static New instance with the updated `suffixAttributes` value.
      *
-     * @phpstan-param scalar|Stringable|UnitEnum|Closure(): mixed $value
+     * @phpstan-param scalar|Closure(): mixed|Stringable|UnitEnum|null $value
      */
     public function setSuffixAttribute(
         string|UnitEnum $key,

--- a/src/HasSuffixCollection.php
+++ b/src/HasSuffixCollection.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace UIAwesome\Html\Mixin;
 
+use Closure;
 use Stringable;
 use UIAwesome\Html\Helper\{AttributeBag, CSSClass};
 use UIAwesome\Html\Interop\{BlockInterface, InlineInterface, VoidInterface};
@@ -35,6 +36,29 @@ trait HasSuffixCollection
      * Tag name for the suffix element, or `false` to disable.
      */
     protected false|BlockInterface|InlineInterface|VoidInterface $suffixTag = false;
+
+    /**
+     * Sets a single HTML attribute for the suffix element.
+     *
+     * Usage example:
+     * ```php
+     * $component->addSuffixAttribute('id', 'my-id');
+     * $component->addSuffixAttribute('id', null);
+     * ```
+     *
+     * @param string|UnitEnum $key Attribute name.
+     * @param mixed $value Attribute value.
+     *
+     * @return static New instance with the updated `suffixAttributes` value.
+     */
+    public function addSuffixAttribute(string|UnitEnum $key, mixed $value): static
+    {
+        $new = clone $this;
+
+        AttributeBag::add($new->suffixAttributes, $key, $value);
+
+        return $new;
+    }
 
     /**
      * Returns the suffix content string assigned to the element.
@@ -100,6 +124,59 @@ trait HasSuffixCollection
     public function getSuffixTag(): BlockInterface|false|InlineInterface|VoidInterface
     {
         return $this->suffixTag;
+    }
+
+    /**
+     * Removes a specific HTML attribute from the suffix element.
+     *
+     * Usage example:
+     * ```php
+     * $component->removeSuffixAttribute('id');
+     * ```
+     *
+     * @param string|UnitEnum $key Attribute name to remove.
+     *
+     * @return static New instance without the specified suffix attribute.
+     */
+    public function removeSuffixAttribute(string|UnitEnum $key): static
+    {
+        $new = clone $this;
+
+        AttributeBag::remove($new->suffixAttributes, $key);
+
+        return $new;
+    }
+
+    /**
+     * Sets a single attribute with prefix handling and value resolution for the suffix element.
+     *
+     * Usage example:
+     * ```php
+     * $component->setSuffixAttribute('label', 'Label', 'aria-');
+     * $component->setSuffixAttribute('hidden', true, 'aria-', true);
+     * ```
+     *
+     * @param string|UnitEnum $key Attribute key without prefix.
+     * @param bool|Closure|float|int|string|Stringable|UnitEnum|null $value Attribute value, or `null` to remove the
+     * attribute.
+     * @param string $prefix Prefix to prepend to the key.
+     * @param bool $boolToString Whether to convert booleans to `true` and `false` strings.
+     *
+     * @return static New instance with the updated `suffixAttributes` value.
+     *
+     * @phpstan-param scalar|Stringable|UnitEnum|Closure(): mixed $value
+     */
+    public function setSuffixAttribute(
+        string|UnitEnum $key,
+        bool|float|int|string|Closure|Stringable|UnitEnum|null $value,
+        string $prefix = '',
+        bool $boolToString = false,
+    ): static {
+        $new = clone $this;
+
+        AttributeBag::set($new->suffixAttributes, $key, $value, $prefix, $boolToString);
+
+        return $new;
     }
 
     /**

--- a/tests/HasAttributesTest.php
+++ b/tests/HasAttributesTest.php
@@ -18,6 +18,7 @@ use UIAwesome\Html\Mixin\HasAttributes;
  * - Ensures fluent setters return new instances (immutability).
  * - Removes attributes and returns expected values.
  * - Sets attributes in bulk and merges new values over existing keys.
+ * - Sets attributes with optional prefixes and boolean string conversion.
  * - Sets single attributes for scalar and enum keys.
  * - Throws InvalidArgumentException for empty or unsupported attribute keys.
  *
@@ -104,6 +105,11 @@ final class HasAttributesTest extends TestCase
             $instance->removeAttribute('tests'),
             'Should return a new instance when removing an attribute, ensuring immutability.',
         );
+        self::assertNotSame(
+            $instance,
+            $instance->setAttribute('tests', ''),
+            'Should return a new instance when setting an attribute, ensuring immutability.',
+        );
     }
 
     public function testSetAttributesValue(): void
@@ -157,6 +163,76 @@ final class HasAttributesTest extends TestCase
             ],
             $instance->getAttributes(),
             'Should merge new attributes with existing ones, overriding duplicates.',
+        );
+    }
+
+    public function testSetAttributesWithPrefixValue(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+        };
+
+        $instance = $instance
+            ->setAttribute('label', 'Label', 'aria-')
+            ->setAttribute('hidden', true, 'aria-', true);
+
+        self::assertSame(
+            [
+                'aria-label' => 'Label',
+                'aria-hidden' => 'true',
+            ],
+            $instance->getAttributes(),
+            "Should return the correct 'aria-' attributes after setting them.",
+        );
+    }
+
+    public function testSetAttributesWithPrefixValueAndBoolStringFalse(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+        };
+
+        $instance = $instance->setAttribute('disabled', true, 'data-');
+
+        self::assertSame(
+            ['data-disabled' => true],
+            $instance->getAttributes(),
+            "Should return the correct 'data-disabled' attribute after setting it.",
+        );
+    }
+
+    public function testSetAttributeWithClosureValue(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+        };
+
+        $closure = static fn(): string => 'resolved-value';
+
+        $instance = $instance->setAttribute('test', $closure, 'data-');
+
+        self::assertSame(
+            ['data-test' => 'resolved-value'],
+            $instance->getAttributes(),
+            "Should return the correct 'data-test' attribute after setting it.",
+        );
+    }
+
+    public function testSetAttributeWithNullValueRemovesAttribute(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+        };
+
+        $instance = $instance
+            ->setAttribute('label', 'Label', 'aria-')
+            ->setAttribute('hidden', true, 'aria-', true)
+            ->setAttribute('label', null, 'aria-');
+
+        self::assertSame(
+            ['aria-hidden' => 'true'],
+            $instance->getAttributes(),
+            "Should remove the attribute when 'null' value is provided.",
         );
     }
 

--- a/tests/HasContainerCollectionTest.php
+++ b/tests/HasContainerCollectionTest.php
@@ -65,6 +65,21 @@ final class HasContainerCollectionTest extends TestCase
         );
     }
 
+    public function testRemoveContainerSingleAttributeValue(): void
+    {
+        $instance = new class {
+            use HasContainerCollection;
+        };
+
+        $instance = $instance->addContainerAttribute('id', 'container-id');
+        $instance = $instance->removeContainerAttribute('id');
+
+        self::assertNull(
+            $instance->getContainerAttribute('id'),
+            "Should return 'null' after removing the 'id' attribute.",
+        );
+    }
+
     public function testReturnNewInstanceWhenSettingContainerCollection(): void
     {
         $instance = new class {
@@ -90,6 +105,21 @@ final class HasContainerCollectionTest extends TestCase
             $instance,
             $instance->containerTag(false),
             'Should return a new instance when setting the container tag, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $instance,
+            $instance->addContainerAttribute('id', 'value'),
+            'Should return a new instance when adding a container attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $instance,
+            $instance->removeContainerAttribute('id'),
+            'Should return a new instance when removing a container attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $instance,
+            $instance->setContainerAttribute('hidden', true, 'aria-', true),
+            'Should return a new instance when setting a container attribute, ensuring immutability.',
         );
     }
 
@@ -149,6 +179,76 @@ final class HasContainerCollectionTest extends TestCase
         );
     }
 
+    public function testSetContainerAttributeWithClosureValue(): void
+    {
+        $instance = new class {
+            use HasContainerCollection;
+        };
+
+        $closure = static fn(): string => 'resolved-value';
+
+        $instance = $instance->setContainerAttribute('test', $closure, 'event-');
+
+        self::assertSame(
+            ['event-test' => 'resolved-value'],
+            $instance->getContainerAttributes(),
+            "Should return the correct 'event-test' attribute after setting it.",
+        );
+    }
+
+    public function testSetContainerAttributeWithNullValueRemovesAttribute(): void
+    {
+        $instance = new class {
+            use HasContainerCollection;
+        };
+
+        $instance = $instance
+            ->setContainerAttribute('label', 'Container', 'aria-')
+            ->setContainerAttribute('hidden', true, 'aria-', true)
+            ->setContainerAttribute('label', null, 'aria-');
+
+        self::assertSame(
+            ['aria-hidden' => 'true'],
+            $instance->getContainerAttributes(),
+            "Should remove the attribute when 'null' value is provided.",
+        );
+    }
+
+    public function testSetContainerAttributeWithPrefixValue(): void
+    {
+        $instance = new class {
+            use HasContainerCollection;
+        };
+
+        $instance = $instance
+            ->setContainerAttribute('label', 'Container', 'aria-')
+            ->setContainerAttribute('hidden', true, 'aria-', true);
+
+        self::assertSame(
+            [
+                'aria-label' => 'Container',
+                'aria-hidden' => 'true',
+            ],
+            $instance->getContainerAttributes(),
+            "Should return the correct 'aria-' attributes after setting them.",
+        );
+    }
+
+    public function testSetContainerAttributeWithPrefixValueAndBoolStringFalse(): void
+    {
+        $instance = new class {
+            use HasContainerCollection;
+        };
+
+        $instance = $instance->setContainerAttribute('disabled', true, 'data-');
+
+        self::assertSame(
+            ['data-disabled' => true],
+            $instance->getContainerAttributes(),
+            "Should return the correct 'data-disabled' attribute after setting it.",
+        );
+    }
+
     public function testSetContainerClassValue(): void
     {
         $instance = new class {
@@ -182,6 +282,21 @@ final class HasContainerCollectionTest extends TestCase
             'override-class',
             $instance->getContainerAttribute('class', ''),
             "Should return the correct container 'class' attribute after setting it.",
+        );
+    }
+
+    public function testSetContainerSingleAttributeValue(): void
+    {
+        $instance = new class {
+            use HasContainerCollection;
+        };
+
+        $instance = $instance->addContainerAttribute('id', 'container-id');
+
+        self::assertSame(
+            'container-id',
+            $instance->getContainerAttribute('id'),
+            "Should return the correct 'id' attribute after setting it.",
         );
     }
 

--- a/tests/HasLabelCollectionTest.php
+++ b/tests/HasLabelCollectionTest.php
@@ -78,6 +78,21 @@ final class HasLabelCollectionTest extends TestCase
         );
     }
 
+    public function testRemoveLabelSingleAttributeValue(): void
+    {
+        $instance = new class {
+            use HasLabelCollection;
+        };
+
+        $instance = $instance->addLabelAttribute('id', 'label-id');
+        $instance = $instance->removeLabelAttribute('id');
+
+        self::assertNull(
+            $instance->getLabelAttribute('id'),
+            "Should return 'null' after removing the 'id' attribute.",
+        );
+    }
+
     public function testReturnNewInstanceWhenSettingLabel(): void
     {
         $instance = new class {
@@ -113,6 +128,16 @@ final class HasLabelCollectionTest extends TestCase
             $instance,
             $instance->removeLabelAttribute('class'),
             'Should return a new instance when removing a label attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $instance,
+            $instance->addLabelAttribute('id', 'value'),
+            'Should return a new instance when adding a label attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $instance,
+            $instance->setLabelAttribute('hidden', true, 'aria-', true),
+            'Should return a new instance when setting a label attribute, ensuring immutability.',
         );
     }
 
@@ -165,6 +190,76 @@ final class HasLabelCollectionTest extends TestCase
             ],
             $instance->getLabelAttributes(),
             'Should merge new attributes with existing ones, overriding duplicates.',
+        );
+    }
+
+    public function testSetLabelAttributeWithClosureValue(): void
+    {
+        $instance = new class {
+            use HasLabelCollection;
+        };
+
+        $closure = static fn(): string => 'resolved-value';
+
+        $instance = $instance->setLabelAttribute('test', $closure, 'event-');
+
+        self::assertSame(
+            ['event-test' => 'resolved-value'],
+            $instance->getLabelAttributes(),
+            "Should return the correct 'event-test' attribute after setting it.",
+        );
+    }
+
+    public function testSetLabelAttributeWithNullValueRemovesAttribute(): void
+    {
+        $instance = new class {
+            use HasLabelCollection;
+        };
+
+        $instance = $instance
+            ->setLabelAttribute('label', 'Label', 'aria-')
+            ->setLabelAttribute('hidden', true, 'aria-', true)
+            ->setLabelAttribute('label', null, 'aria-');
+
+        self::assertSame(
+            ['aria-hidden' => 'true'],
+            $instance->getLabelAttributes(),
+            "Should remove the attribute when 'null' value is provided.",
+        );
+    }
+
+    public function testSetLabelAttributeWithPrefixValue(): void
+    {
+        $instance = new class {
+            use HasLabelCollection;
+        };
+
+        $instance = $instance
+            ->setLabelAttribute('label', 'Label', 'aria-')
+            ->setLabelAttribute('hidden', true, 'aria-', true);
+
+        self::assertSame(
+            [
+                'aria-label' => 'Label',
+                'aria-hidden' => 'true',
+            ],
+            $instance->getLabelAttributes(),
+            "Should return the correct 'aria-' attributes after setting them.",
+        );
+    }
+
+    public function testSetLabelAttributeWithPrefixValueAndBoolStringFalse(): void
+    {
+        $instance = new class {
+            use HasLabelCollection;
+        };
+
+        $instance = $instance->setLabelAttribute('disabled', true, 'data-');
+
+        self::assertSame(
+            ['data-disabled' => true],
+            $instance->getLabelAttributes(),
+            "Should return the correct 'data-disabled' attribute after setting it.",
         );
     }
 
@@ -264,6 +359,21 @@ final class HasLabelCollectionTest extends TestCase
         self::assertNull(
             $instance->getLabelAttribute('for'),
             "Should return 'null' after setting the 'for' attribute to 'null'.",
+        );
+    }
+
+    public function testSetLabelSingleAttributeValue(): void
+    {
+        $instance = new class {
+            use HasLabelCollection;
+        };
+
+        $instance = $instance->addLabelAttribute('id', 'label-id');
+
+        self::assertSame(
+            'label-id',
+            $instance->getLabelAttribute('id'),
+            "Should return the correct 'id' attribute after setting it.",
         );
     }
 

--- a/tests/HasPrefixCollectionTest.php
+++ b/tests/HasPrefixCollectionTest.php
@@ -65,6 +65,21 @@ final class HasPrefixCollectionTest extends TestCase
         );
     }
 
+    public function testRemovePrefixSingleAttributeValue(): void
+    {
+        $instance = new class {
+            use HasPrefixCollection;
+        };
+
+        $instance = $instance->addPrefixAttribute('id', 'prefix-id');
+        $instance = $instance->removePrefixAttribute('id');
+
+        self::assertNull(
+            $instance->getPrefixAttribute('id'),
+            "Should return 'null' after removing the 'id' attribute.",
+        );
+    }
+
     public function testReturnNewInstanceWhenSettingPrefixCollection(): void
     {
         $instance = new class {
@@ -90,6 +105,21 @@ final class HasPrefixCollectionTest extends TestCase
             $instance,
             $instance->prefixTag(Inline::MARK),
             'Should return a new instance when setting the prefix tag, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $instance,
+            $instance->addPrefixAttribute('id', 'value'),
+            'Should return a new instance when adding a prefix attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $instance,
+            $instance->removePrefixAttribute('id'),
+            'Should return a new instance when removing a prefix attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $instance,
+            $instance->setPrefixAttribute('hidden', true, 'aria-', true),
+            'Should return a new instance when setting a prefix attribute, ensuring immutability.',
         );
     }
 
@@ -149,6 +179,76 @@ final class HasPrefixCollectionTest extends TestCase
         );
     }
 
+    public function testSetPrefixAttributeWithClosureValue(): void
+    {
+        $instance = new class {
+            use HasPrefixCollection;
+        };
+
+        $closure = static fn(): string => 'resolved-value';
+
+        $instance = $instance->setPrefixAttribute('test', $closure, 'event-');
+
+        self::assertSame(
+            ['event-test' => 'resolved-value'],
+            $instance->getPrefixAttributes(),
+            "Should return the correct 'event-test' attribute after setting it.",
+        );
+    }
+
+    public function testSetPrefixAttributeWithNullValueRemovesAttribute(): void
+    {
+        $instance = new class {
+            use HasPrefixCollection;
+        };
+
+        $instance = $instance
+            ->setPrefixAttribute('label', 'Prefix', 'aria-')
+            ->setPrefixAttribute('hidden', true, 'aria-', true)
+            ->setPrefixAttribute('label', null, 'aria-');
+
+        self::assertSame(
+            ['aria-hidden' => 'true'],
+            $instance->getPrefixAttributes(),
+            "Should remove the attribute when 'null' value is provided.",
+        );
+    }
+
+    public function testSetPrefixAttributeWithPrefixValue(): void
+    {
+        $instance = new class {
+            use HasPrefixCollection;
+        };
+
+        $instance = $instance
+            ->setPrefixAttribute('label', 'Prefix', 'aria-')
+            ->setPrefixAttribute('hidden', true, 'aria-', true);
+
+        self::assertSame(
+            [
+                'aria-label' => 'Prefix',
+                'aria-hidden' => 'true',
+            ],
+            $instance->getPrefixAttributes(),
+            "Should return the correct 'aria-' attributes after setting them.",
+        );
+    }
+
+    public function testSetPrefixAttributeWithPrefixValueAndBoolStringFalse(): void
+    {
+        $instance = new class {
+            use HasPrefixCollection;
+        };
+
+        $instance = $instance->setPrefixAttribute('disabled', true, 'data-');
+
+        self::assertSame(
+            ['data-disabled' => true],
+            $instance->getPrefixAttributes(),
+            "Should return the correct 'data-disabled' attribute after setting it.",
+        );
+    }
+
     public function testSetPrefixClassValue(): void
     {
         $instance = new class {
@@ -182,6 +282,21 @@ final class HasPrefixCollectionTest extends TestCase
             'override-class',
             $instance->getPrefixAttribute('class', ''),
             "Should return the correct prefix 'class' attribute after setting it.",
+        );
+    }
+
+    public function testSetPrefixSingleAttributeValue(): void
+    {
+        $instance = new class {
+            use HasPrefixCollection;
+        };
+
+        $instance = $instance->addPrefixAttribute('id', 'prefix-id');
+
+        self::assertSame(
+            'prefix-id',
+            $instance->getPrefixAttribute('id'),
+            "Should return the correct 'id' attribute after setting it.",
         );
     }
 

--- a/tests/HasSuffixCollectionTest.php
+++ b/tests/HasSuffixCollectionTest.php
@@ -66,6 +66,21 @@ final class HasSuffixCollectionTest extends TestCase
         );
     }
 
+    public function testRemoveSuffixSingleAttributeValue(): void
+    {
+        $instance = new class {
+            use HasSuffixCollection;
+        };
+
+        $instance = $instance->addSuffixAttribute('id', 'suffix-id');
+        $instance = $instance->removeSuffixAttribute('id');
+
+        self::assertNull(
+            $instance->getSuffixAttribute('id'),
+            "Should return 'null' after removing the 'id' attribute.",
+        );
+    }
+
     public function testReturnNewInstanceWhenSettingSuffixCollection(): void
     {
         $instance = new class {
@@ -91,6 +106,21 @@ final class HasSuffixCollectionTest extends TestCase
             $instance,
             $instance->suffixTag(Inline::MARK),
             'Should return a new instance when setting the suffix tag, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $instance,
+            $instance->addSuffixAttribute('id', 'value'),
+            'Should return a new instance when adding a suffix attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $instance,
+            $instance->removeSuffixAttribute('id'),
+            'Should return a new instance when removing a suffix attribute, ensuring immutability.',
+        );
+        self::assertNotSame(
+            $instance,
+            $instance->setSuffixAttribute('hidden', true, 'aria-', true),
+            'Should return a new instance when setting a suffix attribute, ensuring immutability.',
         );
     }
 
@@ -150,6 +180,76 @@ final class HasSuffixCollectionTest extends TestCase
         );
     }
 
+    public function testSetSuffixAttributeWithClosureValue(): void
+    {
+        $instance = new class {
+            use HasSuffixCollection;
+        };
+
+        $closure = static fn(): string => 'resolved-value';
+
+        $instance = $instance->setSuffixAttribute('test', $closure, 'event-');
+
+        self::assertSame(
+            ['event-test' => 'resolved-value'],
+            $instance->getSuffixAttributes(),
+            "Should return the correct 'event-test' attribute after setting it.",
+        );
+    }
+
+    public function testSetSuffixAttributeWithNullValueRemovesAttribute(): void
+    {
+        $instance = new class {
+            use HasSuffixCollection;
+        };
+
+        $instance = $instance
+            ->setSuffixAttribute('label', 'Suffix', 'aria-')
+            ->setSuffixAttribute('hidden', true, 'aria-', true)
+            ->setSuffixAttribute('label', null, 'aria-');
+
+        self::assertSame(
+            ['aria-hidden' => 'true'],
+            $instance->getSuffixAttributes(),
+            "Should remove the attribute when 'null' value is provided.",
+        );
+    }
+
+    public function testSetSuffixAttributeWithPrefixValue(): void
+    {
+        $instance = new class {
+            use HasSuffixCollection;
+        };
+
+        $instance = $instance
+            ->setSuffixAttribute('label', 'Suffix', 'aria-')
+            ->setSuffixAttribute('hidden', true, 'aria-', true);
+
+        self::assertSame(
+            [
+                'aria-label' => 'Suffix',
+                'aria-hidden' => 'true',
+            ],
+            $instance->getSuffixAttributes(),
+            "Should return the correct 'aria-' attributes after setting them.",
+        );
+    }
+
+    public function testSetSuffixAttributeWithPrefixValueAndBoolStringFalse(): void
+    {
+        $instance = new class {
+            use HasSuffixCollection;
+        };
+
+        $instance = $instance->setSuffixAttribute('disabled', true, 'data-');
+
+        self::assertSame(
+            ['data-disabled' => true],
+            $instance->getSuffixAttributes(),
+            "Should return the correct 'data-disabled' attribute after setting it.",
+        );
+    }
+
     public function testSetSuffixClassValue(): void
     {
         $instance = new class {
@@ -183,6 +283,21 @@ final class HasSuffixCollectionTest extends TestCase
             'override-class',
             $instance->getSuffixAttribute('class', ''),
             'Should return the correct suffix class after setting it.',
+        );
+    }
+
+    public function testSetSuffixSingleAttributeValue(): void
+    {
+        $instance = new class {
+            use HasSuffixCollection;
+        };
+
+        $instance = $instance->addSuffixAttribute('id', 'suffix-id');
+
+        self::assertSame(
+            'suffix-id',
+            $instance->getSuffixAttribute('id'),
+            "Should return the correct 'id' attribute after setting it.",
         );
     }
 


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
