### PR TITLE
feat(mixin): Add prefixed attribute support to `HasAttributes`, `HasLabelCollection`, `HasPrefixCollection`, and `HasSuffixCollection` in attribute bag methods (`attributes()`, `getAttribute()`, `setAttribute()`, `removeAttribute()` and the corresponding collection methods).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.4.2 Under development
 
+- Enh #57: Add prefixed attribute support to `HasAttributes`, `HasLabelCollection`, `HasPrefixCollection`, and `HasSuffixCollection` in attribute bag methods (`attributes()`, `getAttribute()`, `setAttribute()`, `removeAttribute()` and the corresponding collection methods) (@terabytesoftw)
+
 ## 0.4.1 February 15, 2026
 
 - Bug #56: Update attribute tests to directly use resolved values instead of closures (@terabytesoftw)

--- a/README.md
+++ b/README.md
@@ -63,12 +63,13 @@ final class MyComponent
 
 $component = new MyComponent();
 
-$attributes = $component
+$component = $component
     ->setAttribute('id', 'my-component')
     ->attributes(['class' => ['container'], 'role' => 'main'])
     ->attributes(['label' => 'Close'], 'aria-')
-    ->removeAttribute('role')
-    ->getAttributes();
+    ->removeAttribute('role');
+
+$component->getAttributes();
 // ['id' => 'my-component', 'class' => ['container'], 'aria-label' => 'Close']
 
 $component->getAttribute('id', 'default-id');

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ composer require ui-awesome/html-mixin:^0.4
 #### Managing HTML attributes with HasAttributes
 
 The `HasAttributes` trait provides a fluent, immutable API for managing HTML attributes on elements. Supports enum
-keys/values, closure-based values, and array merging.
+keys/values, closure-based values, prefix normalization (for example `aria-`, `data-`, `on`), and array merging.
 
 ```php
 <?php
@@ -64,14 +64,18 @@ final class MyComponent
 $component = new MyComponent();
 
 $attributes = $component
-    ->addAttribute('id', 'my-component')
-    ->attributes(['class' => ['container'], 'data-role' => 'main'])
-    ->removeAttribute('data-role')
+    ->setAttribute('id', 'my-component')
+    ->attributes(['class' => ['container'], 'role' => 'main'])
+    ->attributes(['label' => 'Close'], 'aria-')
+    ->removeAttribute('role')
     ->getAttributes();
-// ['id' => 'my-component', 'class' => ['container']]
+// ['id' => 'my-component', 'class' => ['container'], 'aria-label' => 'Close']
 
 $component->getAttribute('id', 'default-id');
 // 'my-component'
+
+$component->getAttribute('label', null, 'aria-');
+// 'Close'
 ```
 
 #### Managing content with encoding support

--- a/src/HasAttributes.php
+++ b/src/HasAttributes.php
@@ -31,19 +31,21 @@ trait HasAttributes
      * ```php
      * $component->setAttributes(['id' => 'my-id', 'data-role' => 'button']);
      * $component->setAttributes(['size' => ButtonSize::LARGE, 'disabled' => true]);
+     * $component->setAttributes(['aria-label' => 'Close'], 'aria-');
      * ```
      *
      * @param array $values Associative array of attribute keys and values.
+     * @param string $prefix Prefix to ensure (for example, `aria-`, `data-`, `on`).
      *
      * @return static New instance with the updated `attributes` value.
      *
      * @phpstan-param mixed[] $values
      */
-    public function attributes(array $values): static
+    public function attributes(array $values, string $prefix = ''): static
     {
         $new = clone $this;
 
-        AttributeBag::setMany($new->attributes, $values);
+        AttributeBag::setMany($new->attributes, $values, $prefix);
 
         return $new;
     }
@@ -55,16 +57,18 @@ trait HasAttributes
      * ```php
      * $component->getAttribute('id', 'default-id');
      * $component->getAttribute(DataProperty::ID, 'default-id');
+     * $component->getAttribute('aria-label', 'Default Label', 'aria-');
      * ```
      *
      * @param string|UnitEnum $key Attribute name.
      * @param mixed $default Default value when the attribute is missing.
+     * @param string $prefix Prefix to ensure (for example, `aria-`, `data-`, `on`).
      *
      * @return mixed Attribute value or default.
      */
-    public function getAttribute(string|UnitEnum $key, mixed $default = null): mixed
+    public function getAttribute(string|UnitEnum $key, mixed $default = null, string $prefix = ''): mixed
     {
-        return AttributeBag::get($this->attributes, $key, $default);
+        return AttributeBag::get($this->attributes, $key, $default, $prefix);
     }
 
     /**
@@ -91,17 +95,19 @@ trait HasAttributes
      * ```php
      * $component->removeAttribute('id');
      * $component->removeAttribute(DataProperty::ID);
+     * $component->removeAttribute('aria-label', 'aria-');
      * ```
      *
      * @param string|UnitEnum $key Attribute name to remove.
+     * @param string $prefix Prefix to ensure (for example, `aria-`, `data-`, `on`).
      *
      * @return static New instance without the specified `attribute` value.
      */
-    public function removeAttribute(string|UnitEnum $key): static
+    public function removeAttribute(string|UnitEnum $key, string $prefix = ''): static
     {
         $new = clone $this;
 
-        AttributeBag::remove($new->attributes, $key);
+        AttributeBag::remove($new->attributes, $key, $prefix);
 
         return $new;
     }
@@ -115,18 +121,20 @@ trait HasAttributes
      * $component->setAttribute(DataProperty::ID, 'my-id');
      * $component->setAttribute('size', ButtonSize::SMALL);
      * $component->setAttribute('id', null);
+     * $component->setAttribute('aria-label', 'Close', 'aria-');
      * ```
      *
      * @param string|UnitEnum $key Attribute name.
      * @param mixed $value Attribute value.
+     * @param string $prefix Prefix to ensure (for example, `aria-`, `data-`, `on`).
      *
      * @return static New instance with the updated `attributes` value.
      */
-    public function setAttribute(string|UnitEnum $key, mixed $value): static
+    public function setAttribute(string|UnitEnum $key, mixed $value, string $prefix = ''): static
     {
         $new = clone $this;
 
-        AttributeBag::set($new->attributes, $key, $value);
+        AttributeBag::set($new->attributes, $key, $value, $prefix);
 
         return $new;
     }

--- a/src/HasLabelCollection.php
+++ b/src/HasLabelCollection.php
@@ -56,16 +56,18 @@ trait HasLabelCollection
      * Usage example:
      * ```php
      * $component->getLabelAttribute('id', 'default-id');
+     * $component->getLabelAttribute('label', 'default-label', 'aria-');
      * ```
      *
      * @param string|UnitEnum $key Attribute name.
      * @param mixed $default Default value when the attribute is missing.
+     * @param string $prefix Prefix to ensure (for example, `aria-`, `data-`, `on`).
      *
      * @return mixed Attribute value, or `$default` when missing.
      */
-    public function getLabelAttribute(string|UnitEnum $key, mixed $default = null): mixed
+    public function getLabelAttribute(string|UnitEnum $key, mixed $default = null, string $prefix = ''): mixed
     {
-        return AttributeBag::get($this->labelAttributes, $key, $default);
+        return AttributeBag::get($this->labelAttributes, $key, $default, $prefix);
     }
 
     /**
@@ -126,19 +128,21 @@ trait HasLabelCollection
      * Usage example:
      * ```php
      * $component->labelAttributes(['class' => 'form-label']);
+     * $component->labelAttributes(['label' => 'Close'], 'aria-');
      * ```
      *
      * @param array $attributes Label attributes.
+     * @param string $prefix Prefix to ensure (for example, `aria-`, `data-`, `on`).
      *
      * @return static New instance with the updated `labelAttributes` value.
      *
      * @phpstan-param mixed[] $attributes
      */
-    public function labelAttributes(array $attributes): static
+    public function labelAttributes(array $attributes, string $prefix = ''): static
     {
         $new = clone $this;
 
-        AttributeBag::setMany($new->labelAttributes, $attributes);
+        AttributeBag::setMany($new->labelAttributes, $attributes, $prefix);
 
         return $new;
     }
@@ -203,17 +207,19 @@ trait HasLabelCollection
      * ```php
      * $component->labelRemoveAttribute('id');
      * $component->labelRemoveAttribute(DataProperty::ID);
+     * $component->labelRemoveAttribute('label', 'aria-');
      * ```
      *
      * @param string|UnitEnum $key Attribute name to remove.
+     * @param string $prefix Prefix to ensure (for example, `aria-`, `data-`, `on`).
      *
      * @return static New instance without the specified label attribute.
      */
-    public function labelRemoveAttribute(string|UnitEnum $key): static
+    public function labelRemoveAttribute(string|UnitEnum $key, string $prefix = ''): static
     {
         $new = clone $this;
 
-        AttributeBag::remove($new->labelAttributes, $key);
+        AttributeBag::remove($new->labelAttributes, $key, $prefix);
 
         return $new;
     }
@@ -225,18 +231,20 @@ trait HasLabelCollection
      * ```php
      * $component->labelSetAttribute('id', 'my-id');
      * $component->labelSetAttribute('id', null);
+     * $component->labelSetAttribute('label', 'Close', 'aria-');
      * ```
      *
      * @param string|UnitEnum $key Attribute name.
      * @param mixed $value Attribute value.
+     * @param string $prefix Prefix to ensure (for example, `aria-`, `data-`, `on`).
      *
      * @return static New instance with the updated `labelAttributes` value.
      */
-    public function labelSetAttribute(string|UnitEnum $key, mixed $value): static
+    public function labelSetAttribute(string|UnitEnum $key, mixed $value, string $prefix = ''): static
     {
         $new = clone $this;
 
-        AttributeBag::set($new->labelAttributes, $key, $value);
+        AttributeBag::set($new->labelAttributes, $key, $value, $prefix);
 
         return $new;
     }

--- a/src/HasPrefixCollection.php
+++ b/src/HasPrefixCollection.php
@@ -57,16 +57,18 @@ trait HasPrefixCollection
      * Usage example:
      * ```php
      * $component->getPrefixAttribute('id', 'default-id');
+     * $component->getPrefixAttribute('label', 'default-label', 'aria-');
      * ```
      *
      * @param string|UnitEnum $key Attribute name.
      * @param mixed $default Default value when the attribute is missing.
+     * @param string $prefix Prefix to ensure (for example, `aria-`, `data-`, `on`).
      *
      * @return mixed Attribute value or default.
      */
-    public function getPrefixAttribute(string|UnitEnum $key, mixed $default = null): mixed
+    public function getPrefixAttribute(string|UnitEnum $key, mixed $default = null, string $prefix = ''): mixed
     {
-        return AttributeBag::get($this->prefixAttributes, $key, $default);
+        return AttributeBag::get($this->prefixAttributes, $key, $default, $prefix);
     }
 
     /**
@@ -128,19 +130,21 @@ trait HasPrefixCollection
      * Usage example:
      * ```php
      * $component->prefixAttributes(['id' => 'prefix-id']);
+     * $component->prefixAttributes(['label' => 'Start'], 'aria-');
      * ```
      *
      * @param array $values Associative array of attribute keys and values.
+     * @param string $prefix Prefix to ensure (for example, `aria-`, `data-`, `on`).
      *
      * @return static New instance with the updated `prefixAttributes` value.
      *
      * @phpstan-param mixed[] $values
      */
-    public function prefixAttributes(array $values): static
+    public function prefixAttributes(array $values, string $prefix = ''): static
     {
         $new = clone $this;
 
-        AttributeBag::setMany($new->prefixAttributes, $values);
+        AttributeBag::setMany($new->prefixAttributes, $values, $prefix);
 
         return $new;
     }
@@ -174,17 +178,19 @@ trait HasPrefixCollection
      * Usage example:
      * ```php
      * $component->prefixRemoveAttribute('id');
+     * $component->prefixRemoveAttribute('label', 'aria-');
      * ```
      *
      * @param string|UnitEnum $key Attribute name to remove.
+     * @param string $prefix Prefix to ensure (for example, `aria-`, `data-`, `on`).
      *
      * @return static New instance without the specified prefix attribute.
      */
-    public function prefixRemoveAttribute(string|UnitEnum $key): static
+    public function prefixRemoveAttribute(string|UnitEnum $key, string $prefix = ''): static
     {
         $new = clone $this;
 
-        AttributeBag::remove($new->prefixAttributes, $key);
+        AttributeBag::remove($new->prefixAttributes, $key, $prefix);
 
         return $new;
     }
@@ -196,18 +202,20 @@ trait HasPrefixCollection
      * ```php
      * $component->prefixSetAttribute('id', 'my-id');
      * $component->prefixSetAttribute('id', null);
+     * $component->prefixSetAttribute('label', 'Start', 'aria-');
      * ```
      *
      * @param string|UnitEnum $key Attribute name.
      * @param mixed $value Attribute value.
+     * @param string $prefix Prefix to ensure (for example, `aria-`, `data-`, `on`).
      *
      * @return static New instance with the updated `prefixAttributes` value.
      */
-    public function prefixSetAttribute(string|UnitEnum $key, mixed $value): static
+    public function prefixSetAttribute(string|UnitEnum $key, mixed $value, string $prefix = ''): static
     {
         $new = clone $this;
 
-        AttributeBag::set($new->prefixAttributes, $key, $value);
+        AttributeBag::set($new->prefixAttributes, $key, $value, $prefix);
 
         return $new;
     }

--- a/src/HasSuffixCollection.php
+++ b/src/HasSuffixCollection.php
@@ -57,16 +57,18 @@ trait HasSuffixCollection
      * Usage example:
      * ```php
      * $component->getSuffixAttribute('id', 'default-id');
+     * $component->getSuffixAttribute('label', 'default-label', 'aria-');
      * ```
      *
      * @param string|UnitEnum $key Attribute name.
      * @param mixed $default Default value when the attribute is missing.
+     * @param string $prefix Prefix to ensure (for example, `aria-`, `data-`, `on`).
      *
      * @return mixed Attribute value or default.
      */
-    public function getSuffixAttribute(string|UnitEnum $key, mixed $default = null): mixed
+    public function getSuffixAttribute(string|UnitEnum $key, mixed $default = null, string $prefix = ''): mixed
     {
-        return AttributeBag::get($this->suffixAttributes, $key, $default);
+        return AttributeBag::get($this->suffixAttributes, $key, $default, $prefix);
     }
 
     /**
@@ -128,19 +130,21 @@ trait HasSuffixCollection
      * Usage example:
      * ```php
      * $component->suffixAttributes(['id' => 'suffix-id']);
+     * $component->suffixAttributes(['label' => 'End'], 'aria-');
      * ```
      *
      * @param array $values Associative array of attribute keys and values.
+     * @param string $prefix Prefix to ensure (for example, `aria-`, `data-`, `on`).
      *
      * @return static New instance with the updated `suffixAttributes` value.
      *
      * @phpstan-param mixed[] $values
      */
-    public function suffixAttributes(array $values): static
+    public function suffixAttributes(array $values, string $prefix = ''): static
     {
         $new = clone $this;
 
-        AttributeBag::setMany($new->suffixAttributes, $values);
+        AttributeBag::setMany($new->suffixAttributes, $values, $prefix);
 
         return $new;
     }
@@ -174,17 +178,19 @@ trait HasSuffixCollection
      * Usage example:
      * ```php
      * $component->suffixRemoveAttribute('id');
+     * $component->suffixRemoveAttribute('label', 'aria-');
      * ```
      *
      * @param string|UnitEnum $key Attribute name to remove.
+     * @param string $prefix Prefix to ensure (for example, `aria-`, `data-`, `on`).
      *
      * @return static New instance without the specified suffix attribute.
      */
-    public function suffixRemoveAttribute(string|UnitEnum $key): static
+    public function suffixRemoveAttribute(string|UnitEnum $key, string $prefix = ''): static
     {
         $new = clone $this;
 
-        AttributeBag::remove($new->suffixAttributes, $key);
+        AttributeBag::remove($new->suffixAttributes, $key, $prefix);
 
         return $new;
     }
@@ -196,18 +202,20 @@ trait HasSuffixCollection
      * ```php
      * $component->suffixSetAttribute('id', 'my-id');
      * $component->suffixSetAttribute('id', null);
+     * $component->suffixSetAttribute('label', 'End', 'aria-');
      * ```
      *
      * @param string|UnitEnum $key Attribute name.
      * @param mixed $value Attribute value.
+     * @param string $prefix Prefix to ensure (for example, `aria-`, `data-`, `on`).
      *
      * @return static New instance with the updated `suffixAttributes` value.
      */
-    public function suffixSetAttribute(string|UnitEnum $key, mixed $value): static
+    public function suffixSetAttribute(string|UnitEnum $key, mixed $value, string $prefix = ''): static
     {
         $new = clone $this;
 
-        AttributeBag::set($new->suffixAttributes, $key, $value);
+        AttributeBag::set($new->suffixAttributes, $key, $value, $prefix);
 
         return $new;
     }

--- a/tests/HasAttributesTest.php
+++ b/tests/HasAttributesTest.php
@@ -62,6 +62,7 @@ final class HasAttributesTest extends TestCase
             "Should remove the prefixed 'aria-label' attribute.",
         );
     }
+
     public function testAttributesValue(): void
     {
         $instance = new class {

--- a/tests/HasAttributesTest.php
+++ b/tests/HasAttributesTest.php
@@ -29,6 +29,39 @@ use UIAwesome\Html\Mixin\HasAttributes;
 #[Group('mixin')]
 final class HasAttributesTest extends TestCase
 {
+    public function testAttributesPrefixSupport(): void
+    {
+        $instance = new class {
+            use HasAttributes;
+        };
+
+        $instance = $instance->setAttribute('label', 'label', 'aria-');
+
+        self::assertSame(
+            'label',
+            $instance->getAttribute('label', null, 'aria-'),
+            "Should read the prefixed 'aria-label' attribute when using the 'aria-' prefix.",
+        );
+        self::assertNull(
+            $instance->getAttribute('label'),
+            "Should not read the prefixed 'aria-label' attribute without the prefix.",
+        );
+
+        $instance = $instance->attributes(['describedby' => 'field-id'], 'aria-');
+
+        self::assertSame(
+            'field-id',
+            $instance->getAttribute('describedby', null, 'aria-'),
+            "Should set and read prefixed attributes via 'attributes()'.",
+        );
+
+        $instance = $instance->removeAttribute('label', 'aria-');
+
+        self::assertNull(
+            $instance->getAttribute('label', null, 'aria-'),
+            "Should remove the prefixed 'aria-label' attribute.",
+        );
+    }
     public function testAttributesValue(): void
     {
         $instance = new class {

--- a/tests/HasLabelCollectionTest.php
+++ b/tests/HasLabelCollectionTest.php
@@ -57,6 +57,40 @@ final class HasLabelCollectionTest extends TestCase
         );
     }
 
+    public function testLabelAttributesPrefixSupport(): void
+    {
+        $instance = new class {
+            use HasLabelCollection;
+        };
+
+        $instance = $instance->labelSetAttribute('label', 'label', 'aria-');
+
+        self::assertSame(
+            'label',
+            $instance->getLabelAttribute('label', null, 'aria-'),
+            "Should read the prefixed 'aria-label' attribute when using the 'aria-' prefix.",
+        );
+        self::assertNull(
+            $instance->getLabelAttribute('label'),
+            "Should not read the prefixed 'aria-label' attribute without the prefix.",
+        );
+
+        $instance = $instance->labelAttributes(['describedby' => 'field-id'], 'aria-');
+
+        self::assertSame(
+            'field-id',
+            $instance->getLabelAttribute('describedby', null, 'aria-'),
+            "Should set and read prefixed attributes via 'labelAttributes()'.",
+        );
+
+        $instance = $instance->labelRemoveAttribute('label', 'aria-');
+
+        self::assertNull(
+            $instance->getLabelAttribute('label', null, 'aria-'),
+            "Should remove the prefixed 'aria-label' attribute.",
+        );
+    }
+
     public function testLabelAttributesValue(): void
     {
         $instance = new class {

--- a/tests/HasPrefixCollectionTest.php
+++ b/tests/HasPrefixCollectionTest.php
@@ -66,6 +66,40 @@ final class HasPrefixCollectionTest extends TestCase
         );
     }
 
+    public function testPrefixAttributesPrefixSupport(): void
+    {
+        $instance = new class {
+            use HasPrefixCollection;
+        };
+
+        $instance = $instance->prefixSetAttribute('label', 'label', 'aria-');
+
+        self::assertSame(
+            'label',
+            $instance->getPrefixAttribute('label', null, 'aria-'),
+            "Should read the prefixed 'aria-label' attribute when using the 'aria-' prefix.",
+        );
+        self::assertNull(
+            $instance->getPrefixAttribute('label'),
+            "Should not read the prefixed 'aria-label' attribute without the prefix.",
+        );
+
+        $instance = $instance->prefixAttributes(['describedby' => 'prefix-id'], 'aria-');
+
+        self::assertSame(
+            'prefix-id',
+            $instance->getPrefixAttribute('describedby', null, 'aria-'),
+            "Should set and read prefixed attributes via 'prefixAttributes()'.",
+        );
+
+        $instance = $instance->prefixRemoveAttribute('label', 'aria-');
+
+        self::assertNull(
+            $instance->getPrefixAttribute('label', null, 'aria-'),
+            "Should remove the prefixed 'aria-label' attribute.",
+        );
+    }
+
     public function testPrefixAttributesValue(): void
     {
         $instance = new class {

--- a/tests/HasSuffixCollectionTest.php
+++ b/tests/HasSuffixCollectionTest.php
@@ -196,6 +196,40 @@ final class HasSuffixCollectionTest extends TestCase
         );
     }
 
+    public function testSuffixAttributesPrefixSupport(): void
+    {
+        $instance = new class {
+            use HasSuffixCollection;
+        };
+
+        $instance = $instance->suffixSetAttribute('label', 'label', 'aria-');
+
+        self::assertSame(
+            'label',
+            $instance->getSuffixAttribute('label', null, 'aria-'),
+            "Should read the prefixed 'aria-label' attribute when using the 'aria-' prefix.",
+        );
+        self::assertNull(
+            $instance->getSuffixAttribute('label'),
+            "Should not read the prefixed 'aria-label' attribute without the prefix.",
+        );
+
+        $instance = $instance->suffixAttributes(['describedby' => 'suffix-id'], 'aria-');
+
+        self::assertSame(
+            'suffix-id',
+            $instance->getSuffixAttribute('describedby', null, 'aria-'),
+            "Should set and read prefixed attributes via 'suffixAttributes()'.",
+        );
+
+        $instance = $instance->suffixRemoveAttribute('label', 'aria-');
+
+        self::assertNull(
+            $instance->getSuffixAttribute('label', null, 'aria-'),
+            "Should remove the prefixed 'aria-label' attribute.",
+        );
+    }
+
     public function testSuffixAttributesValue(): void
     {
         $instance = new class {


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
