### PR TITLE
fix(mixin); Remove `ui-awesome/html-interop` from runtime dependencies and keep it as development-only dependency for local tooling/tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # ChangeLog
 
-## 0.4.3 Under development
+## 0.5.0 Under development
+
+- Bug #58: Remove `ui-awesome/html-interop` from runtime dependencies and keep it as development-only dependency for local tooling/tests (@terabytesoftw)
 
 ## 0.4.2 February 15, 2026
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 ### Installation
 
 ```bash
-composer require ui-awesome/html-mixin:^0.4
+composer require ui-awesome/html-mixin:^0.5
 ```
 
 ### Quick start
@@ -150,6 +150,9 @@ echo $component
 The `HasPrefixCollection` and `HasSuffixCollection` traits add content before and after your element, optionally wrapped
 in tags with their own attributes.
 
+Tag APIs now accept `UnitEnum`, so your components can use any project enum without a direct runtime dependency on
+`ui-awesome/html-interop`.
+
 ```php
 <?php
 
@@ -158,7 +161,12 @@ declare(strict_types=1);
 namespace App\Component;
 
 use UIAwesome\Html\Mixin\{HasContent, HasPrefixCollection, HasSuffixCollection};
-use UIAwesome\Html\Interop\Inline;
+
+enum InlineTag: string
+{
+    case STRONG = 'strong';
+    case EM = 'em';
+}
 
 final class MyComponent
 {
@@ -178,9 +186,9 @@ echo $component
     ->content('Main Content')
     ->prefix('Prefix: ')
     ->prefixAttributes(['class' => 'prefix-badge'])
-    ->prefixTag(Inline::STRONG)
+    ->prefixTag(InlineTag::STRONG)
     ->suffix(' :Suffix')
-    ->suffixTag(Inline::EM)
+    ->suffixTag(InlineTag::EM)
     ->render();
 // <strong class="prefix-badge">Prefix: </strong>Main Content<em> :Suffix</em>
 ```
@@ -191,6 +199,7 @@ For detailed configuration options and advanced usage.
 
 - 🧪 [Testing Guide](docs/testing.md)
 - 🛠️ [Development Guide](docs/development.md)
+- ⬆️ [Upgrade Guide](UPGRADE.md)
 
 ## Package information
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,39 @@
+# Upgrade Guide
+
+## 0.5.0
+
+### Runtime dependencies
+
+- `ui-awesome/html-interop` is no longer required at runtime by `ui-awesome/html-mixin`.
+- If your application uses enums from `ui-awesome/html-interop`, require it directly in your project.
+
+### Tag APIs now use `UnitEnum`
+
+The following APIs now accept `false|UnitEnum`:
+
+- `containerTag()` / `getContainerTag()`
+- `prefixTag()` / `getPrefixTag()`
+- `suffixTag()` / `getSuffixTag()`
+
+This replaces the interop-specific interface unions (`BlockInterface`, `InlineInterface`, `VoidInterface`).
+
+### Migration example
+
+Before:
+
+```php
+use UIAwesome\Html\Interop\Inline;
+
+$component = $component->prefixTag(Inline::STRONG);
+```
+
+After (project enum):
+
+```php
+enum InlineTag: string
+{
+    case STRONG = 'strong';
+}
+
+$component = $component->prefixTag(InlineTag::STRONG);
+```

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "^8.1",
-        "ui-awesome/html-helper": "^0.7",
-        "ui-awesome/html-interop": "^0.3"
+        "ui-awesome/html-helper": "^0.7"
     },
     "require-dev": {
+        "ui-awesome/html-interop": "^0.4@dev",
         "infection/infection": "^0.27|^0.32",
         "maglnet/composer-require-checker": "^4.1",
         "php-forge/coding-standard": "^0.1",

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,6 +2,14 @@
 
 This document describes development workflows and maintenance tasks for the project.
 
+## Tag enum contracts
+
+Mixin APIs that configure tags (`containerTag()`, `prefixTag()`, `suffixTag()`) now use `UnitEnum` as the shared
+contract. This package no longer requires `ui-awesome/html-interop` as a direct runtime dependency.
+
+- Reuse your own project enums, as long as they are enums (`UnitEnum`/backed enums).
+- Keep `ui-awesome/html-interop` only if your project already uses its tag enums.
+
 ## Sync Metadata
 
 To keep configuration files synchronized with the latest template updates, use the `sync-metadata` command. This command

--- a/docs/svgs/features-mobile.svg
+++ b/docs/svgs/features-mobile.svg
@@ -59,7 +59,7 @@
                 </div>
                 <div class="alert-box">
                     <p class="alert-title"><strong>HasPrefix/SuffixCollection</strong></p>
-                    <p class="alert-content">Render content before/after elements with optional tag wrapping and independent attribute management</p>
+                    <p class="alert-content">Render content before/after elements with optional UnitEnum tag wrapping and independent attribute management</p>
                 </div>
             </div>
         </div>

--- a/docs/svgs/features.svg
+++ b/docs/svgs/features.svg
@@ -57,7 +57,7 @@
                 </div>
                 <div class="alert-box">
                     <p class="alert-title"><strong>HasPrefix/SuffixCollection</strong></p>
-                    <p class="alert-content">Render content before/after elements with optional tag wrapping and independent attribute management</p>
+                    <p class="alert-content">Render content before/after elements with optional UnitEnum tag wrapping and independent attribute management</p>
                 </div>
             </div>
         </div>

--- a/src/HasContainerCollection.php
+++ b/src/HasContainerCollection.php
@@ -6,7 +6,6 @@ namespace UIAwesome\Html\Mixin;
 
 use Stringable;
 use UIAwesome\Html\Helper\{AttributeBag, CSSClass};
-use UIAwesome\Html\Interop\BlockInterface;
 use UnitEnum;
 
 /**
@@ -32,7 +31,7 @@ trait HasContainerCollection
     /**
      * Tag name for the container element, or `false` to disable.
      */
-    protected false|BlockInterface $containerTag = false;
+    protected false|UnitEnum $containerTag = false;
 
     /**
      * Sets whether to render the container.
@@ -153,11 +152,11 @@ trait HasContainerCollection
      * $component->containerTag(false);
      * ```
      *
-     * @param BlockInterface|false $value Tag name for the container element, or `false` to disable.
+     * @param false|UnitEnum $value Tag name for the container element, or `false` to disable.
      *
      * @return static New instance with the updated `containerTag` value.
      */
-    public function containerTag(BlockInterface|false $value): static
+    public function containerTag(false|UnitEnum $value): static
     {
         $new = clone $this;
         $new->containerTag = $value;
@@ -208,9 +207,9 @@ trait HasContainerCollection
      * $component->getContainerTag();
      * ```
      *
-     * @return BlockInterface|false Tag name for the container element, or `false` to disable.
+     * @return false|UnitEnum Tag name for the container element, or `false` to disable.
      */
-    public function getContainerTag(): false|BlockInterface
+    public function getContainerTag(): false|UnitEnum
     {
         return $this->containerTag;
     }

--- a/src/HasPrefixCollection.php
+++ b/src/HasPrefixCollection.php
@@ -6,7 +6,6 @@ namespace UIAwesome\Html\Mixin;
 
 use Stringable;
 use UIAwesome\Html\Helper\{AttributeBag, CSSClass};
-use UIAwesome\Html\Interop\{BlockInterface, InlineInterface, VoidInterface};
 use UnitEnum;
 
 use function implode;
@@ -34,7 +33,7 @@ trait HasPrefixCollection
     /**
      * Tag name for the prefix element, or `false` to disable.
      */
-    protected false|BlockInterface|InlineInterface|VoidInterface $prefixTag = false;
+    protected false|UnitEnum $prefixTag = false;
 
     /**
      * Returns the prefix content string assigned to the element.
@@ -96,10 +95,9 @@ trait HasPrefixCollection
      * $component->getPrefixTag();
      * ```
      *
-     * @return BlockInterface|false|InlineInterface|VoidInterface Tag name for the prefix element, or `false` to
-     * disable.
+     * @return false|UnitEnum Tag name for the prefix element, or `false` to disable.
      */
-    public function getPrefixTag(): BlockInterface|false|InlineInterface|VoidInterface
+    public function getPrefixTag(): false|UnitEnum
     {
         return $this->prefixTag;
     }
@@ -158,7 +156,7 @@ trait HasPrefixCollection
      * $component->prefixClass('override-class', true);
      * ```
      *
-     * @param string|Stringable|UnitEnum|null$value CSS class name to add.
+     * @param string|Stringable|UnitEnum|null $value CSS class name to add.
      * @param bool $override Whether to override existing class value.
      *
      * @return static New instance with the updated `prefixAttributes` value.
@@ -229,12 +227,11 @@ trait HasPrefixCollection
      * $component->prefixTag(false);
      * ```
      *
-     * @param BlockInterface|false|InlineInterface|VoidInterface $value Tag name for the prefix element, or `false` to
-     * disable.
+     * @param false|UnitEnum $value Tag name for the prefix element, or `false` to disable.
      *
      * @return static New instance with the updated `prefixTag` value.
      */
-    public function prefixTag(false|BlockInterface|InlineInterface|VoidInterface $value = false): static
+    public function prefixTag(false|UnitEnum $value = false): static
     {
         $new = clone $this;
         $new->prefixTag = $value;

--- a/src/HasPrefixCollection.php
+++ b/src/HasPrefixCollection.php
@@ -223,7 +223,7 @@ trait HasPrefixCollection
      *
      * Usage example:
      * ```php
-     * $component->prefixTag(\UIAwesome\Html\Interop\Inline::SPAN);
+     * $component->prefixTag(Inline::SPAN);
      * $component->prefixTag(false);
      * ```
      *

--- a/src/HasSuffixCollection.php
+++ b/src/HasSuffixCollection.php
@@ -223,7 +223,7 @@ trait HasSuffixCollection
      *
      * Usage example:
      * ```php
-     * $component->suffixTag(\UIAwesome\Html\InteropInline::SPAN);
+     * $component->suffixTag(Inline::SPAN);
      * $component->suffixTag(false);
      * ```
      *

--- a/src/HasSuffixCollection.php
+++ b/src/HasSuffixCollection.php
@@ -6,7 +6,6 @@ namespace UIAwesome\Html\Mixin;
 
 use Stringable;
 use UIAwesome\Html\Helper\{AttributeBag, CSSClass};
-use UIAwesome\Html\Interop\{BlockInterface, InlineInterface, VoidInterface};
 use UnitEnum;
 
 use function implode;
@@ -34,7 +33,7 @@ trait HasSuffixCollection
     /**
      * Tag name for the suffix element, or `false` to disable.
      */
-    protected false|BlockInterface|InlineInterface|VoidInterface $suffixTag = false;
+    protected false|UnitEnum $suffixTag = false;
 
     /**
      * Returns the suffix content string assigned to the element.
@@ -96,10 +95,9 @@ trait HasSuffixCollection
      * $component->getSuffixTag();
      * ```
      *
-     * @return BlockInterface|false|InlineInterface|VoidInterface Tag name for the suffix element, or `false` to
-     * disable.
+     * @return false|UnitEnum Tag name for the suffix element, or `false` to disable.
      */
-    public function getSuffixTag(): BlockInterface|false|InlineInterface|VoidInterface
+    public function getSuffixTag(): false|UnitEnum
     {
         return $this->suffixTag;
     }
@@ -229,12 +227,11 @@ trait HasSuffixCollection
      * $component->suffixTag(false);
      * ```
      *
-     * @param BlockInterface|false|InlineInterface|VoidInterface $value Tag name for the suffix element, or `false` to
-     * disable.
+     * @param false|UnitEnum $value Tag name for the suffix element, or `false` to disable.
      *
      * @return static New instance with the updated `suffixTag` value.
      */
-    public function suffixTag(false|BlockInterface|InlineInterface|VoidInterface $value = false): static
+    public function suffixTag(false|UnitEnum $value = false): static
     {
         $new = clone $this;
         $new->suffixTag = $value;

--- a/src/HasSuffixCollection.php
+++ b/src/HasSuffixCollection.php
@@ -223,7 +223,7 @@ trait HasSuffixCollection
      *
      * Usage example:
      * ```php
-     * $component->suffixTag(\UIAwesome\Html\Interop\Inline::SPAN);
+     * $component->suffixTag(\UIAwesome\Html\InteropInline::SPAN);
      * $component->suffixTag(false);
      * ```
      *


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ✔️                                                              |
